### PR TITLE
Do not use workspaces if there is no dirs in config

### DIFF
--- a/terrat_runner/repo_config.py
+++ b/terrat_runner/repo_config.py
@@ -92,7 +92,7 @@ def get_parallelism(repo_config):
 def get_create_and_select_workspace(repo_config, path):
     dirs = repo_config.get('dirs')
     if dirs is None:
-        dirs = {}
+        return False
     return dirs.get(path, {}).get('create_and_select_workspace', True)
 
 


### PR DESCRIPTION
I don't use additional Terraform workspaces then I have an error:

```
DEBUG:root:EXEC : DIR : .
DEBUG:root:CMD : cmd=['/usr/local/tf/versions/latest/terraform', 'init'] : cwd=/github/workspace/.
INFO:root:WORKFLOW_STEP_INIT : CREATE_AND_SELECT_WORKSPACE : . : True
DEBUG:root:CMD : cmd=['/usr/local/tf/versions/latest/terraform', 'workspace', 'select', 'default'] : cwd=/github/workspace/.
workspaces not supported
DEBUG:root:CMD : cmd=['/usr/local/tf/versions/latest/terraform', 'workspace', 'new', 'default'] : cwd=/github/workspace/.
Failed to get configured named states: workspaces not supported
```

Creation of the new workspace should be disabled when there is no "dirs" and eventually it should be disabled for "default" workspace maybe.
