### PR TITLE
ADD Directory structure of repo to work manifest

### DIFF
--- a/terrat_runner/work_exec.py
+++ b/terrat_runner/work_exec.py
@@ -49,7 +49,7 @@ def _run(state, exec_cb):
         raise Exception('Failed executing pre hooks')
 
     res = dir_exec.run(rc.get_parallelism(state.repo_config),
-                       state.work_manifest['dirs'],
+                       state.work_manifest.get('changed_dirspaces', state.work_manifest.get('dirs')),
                        exec_cb.exec,
                        (state,))
 


### PR DESCRIPTION
This is preparation for future features that will need to know the directory structure.  This will work with the current version of the backend and the next version of the backend which will include the directory structure.