### PR TITLE
FIX Branches with slashs that also match a dirname fail

### DIFF
--- a/terrat_runner/workflow_step_checkout_strategy.py
+++ b/terrat_runner/workflow_step_checkout_strategy.py
@@ -10,7 +10,7 @@ def perform_merge(git_workspace, base_ref, head_ref):
     subprocess.check_call(['git', 'config', '--global', 'user.name', 'Terrateam Action'])
     subprocess.check_call(['git', 'config', '--global', 'advice.detachedHead', 'false'])
     subprocess.check_call(['git', 'branch'], cwd=git_workspace)
-    subprocess.check_call(['git', 'checkout', base_ref], cwd=git_workspace)
+    subprocess.check_call(['git', 'checkout', base_ref, '--'], cwd=git_workspace)
     subprocess.check_call(['git', 'merge', '--no-commit', head_ref], cwd=git_workspace)
 
 


### PR DESCRIPTION
This is due to a git ambiguity where it isn't sure if that is a
pathspec or a branch name.