### PR TITLE
terrateamio/terrateam#393 FIX Terraform command not found sometimes

### DIFF
--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -32,7 +32,12 @@ class Engine:
             lambda: cmd.run_with_output(
                 state,
                 {
-                    'cmd': [self.tf_cmd, 'init'] + config.get('extra_args', [])
+                    'cmd': [
+                        'flock',
+                        '/tmp/tf-init.lock',
+                        self.tf_cmd,
+                        'init'
+                    ] + config.get('extra_args', [])
                 }),
             retry.finite_tries(TRIES, lambda result: result[0].returncode != 0),
             retry.betwixt_sleep_with_backoff(INITIAL_SLEEP, BACKOFF))


### PR DESCRIPTION
Sometimes the terraform command is not found if multiple inits are executed concurrently.  Toss an flock around that to serialize just the inits.