### PR TITLE
Add support for terraform/opentofu shared provider cache

### DIFF
--- a/.terraformrc
+++ b/.terraformrc
@@ -1,0 +1,1 @@
+plugin_cache_dir = "$HOME/.terraform.d/plugin-cache/"

--- a/.tofurc
+++ b/.tofurc
@@ -1,0 +1,1 @@
+plugin_cache_dir = "$HOME/.terraform.d/plugin-cache/"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -26,6 +26,10 @@ RUN apt-get update \
 	unzip \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Create and configure terraform/opentofu plugin-cache directory.
+RUN mkdir -p /root/.terraform.d/plugin-cache/
+COPY .terraformrc .tofurc /root/
+
 ARG TENV_LATEST_VERSION=v4.2.4
 RUN echo "TENV_LATEST_VERSION: ${TENV_LATEST_VERSION}" && \
     ARCH=$(dpkg --print-architecture) && \


### PR DESCRIPTION
Currently each terrateam action run downloads providers per dirspace.
This is inefficient in both bandwidth, time and disk space.

This PR implements the use of a common plugin cache directory that all providers are downloaded to according to terraform and opentofu documentation.
Plugins will be downloaded once per version to the plugin cache directory and then re-used from the cache for consecutive runs. 

Documentation: 
https://developer.hashicorp.com/terraform/cli/config/config-file
https://opentofu.org/docs/cli/config/config-file/

