### PR TITLE
Allow container building on forks

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -13,6 +13,11 @@ name: build-base
 # pinning to an action commit SHA truly isolates users from future base image changes.
 on:
   workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -34,7 +39,7 @@ jobs:
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
@@ -43,7 +48,7 @@ jobs:
         with:
           push: true
           file: Dockerfile.base
-          tags: ghcr.io/terrateamio/action-base:${{ steps.tag.outputs.tag }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base:${{ steps.tag.outputs.tag }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - 'v1'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -20,7 +25,7 @@ jobs:
         name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
@@ -29,5 +34,5 @@ jobs:
         with:
           push: true
           file: Dockerfile
-          tags: ghcr.io/terrateamio/action:v1
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I modified the workflows to use the ${{ github.repository }}  variable to allow building and publishing on forks.

Also I replaced the hardcoded `v1` with `${{ github.ref_name }}` which is the branch name.
Since the trigger for the ci workflow is a push to the `v1` branch in the future we can add `v2` and we wont have to modify the workflow to support the v2 tag.