### PR TITLE
Pulumi Engine: plan output missing from PR comments and broken has_changes

### DIFF
--- a/terrat_runner/engine_pulumi.py
+++ b/terrat_runner/engine_pulumi.py
@@ -66,7 +66,7 @@ def plan(state, config):
     (proc, stdout, stderr) = cmd.run_with_output(
         state,
         {
-            'cmd': ['pulumi', 'preview'] + config.get('extra_args', [])
+            'cmd': ['pulumi', 'preview', '--diff'] + config.get('extra_args', [])
         })
 
     with open(state.env['TERRATEAM_PLAN_FILE'], 'w') as f:

--- a/terrat_runner/engine_pulumi.py
+++ b/terrat_runner/engine_pulumi.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import cmd
 import engine
@@ -44,6 +45,11 @@ def apply(state, config):
 
 
 def diff(state, config):
+    # Read the preview output saved by plan()
+    diff_file = state.env['TERRATEAM_PLAN_FILE'] + '.diff'
+    if os.path.exists(diff_file):
+        with open(diff_file, 'r') as f:
+            return (True, f.read(), '')
     return None
 
 
@@ -66,8 +72,11 @@ def plan(state, config):
     with open(state.env['TERRATEAM_PLAN_FILE'], 'w') as f:
         f.write('{}')
 
+    # Save preview output for diff() to pick up
+    with open(state.env['TERRATEAM_PLAN_FILE'] + '.diff', 'w') as f:
+        f.write(stdout)
+
     success = proc.returncode == 0
-    # Pulumi preview shows "to create", "to update", "to delete", "to replace" when there are changes
     change_indicators = ['to create', 'to update', 'to delete', 'to replace']
     has_changes = success and any(ind in stdout for ind in change_indicators)
     return (success, has_changes, stdout, stderr)

--- a/terrat_runner/engine_pulumi.py
+++ b/terrat_runner/engine_pulumi.py
@@ -1,8 +1,22 @@
+import json
 import logging
 import os
+import re
 
 import cmd
 import engine
+
+
+def format_diff(text):
+    """Reformat diff markers for GitHub syntax highlighting.
+
+    Moves +/-/~ from after indentation to start of line so GitHub's
+    ```diff code fence colors them. Replaces ~ with ! for changed lines.
+    Same approach as engine_tf.py.
+    """
+    s = re.sub(r'^(\s+)([+\-~])', r'\2\1', text, flags=re.MULTILINE)
+    s = re.sub(r'^~', r'!', s, flags=re.MULTILINE)
+    return s
 
 
 def init(state, config):
@@ -45,16 +59,35 @@ def apply(state, config):
 
 
 def diff(state, config):
-    # Read the preview output saved by plan()
+    """Read the preview --diff output saved by plan() and format for GitHub highlighting."""
     diff_file = state.env['TERRATEAM_PLAN_FILE'] + '.diff'
     if os.path.exists(diff_file):
         with open(diff_file, 'r') as f:
-            return (True, f.read(), '')
+            stdout = f.read()
+        return (True, format_diff(stdout), '')
     return None
 
 
 def diff_json(state, config):
-    return None
+    """Run pulumi preview -j for structured JSON diff data."""
+    logging.info(
+        'DIFF_JSON : %s : engine=%s',
+        state.path,
+        state.workflow['engine']['name'])
+
+    (proc, stdout, stderr) = cmd.run_with_output(
+        state,
+        {
+            'cmd': ['pulumi', 'preview', '-j']
+        })
+
+    if proc.returncode == 0:
+        try:
+            return (True, json.loads(stdout))
+        except json.JSONDecodeError as exn:
+            return (False, stdout, str(exn))
+
+    return (False, stdout, stderr)
 
 
 def plan(state, config):
@@ -98,12 +131,19 @@ def unsafe_apply(state, config):
 
 
 def outputs(state, config):
+    """Collect stack outputs via pulumi stack output --json."""
     logging.info(
         'OUTPUTS : %s : engine=%s',
         state.path,
         state.workflow['engine']['name'])
 
-    return None
+    (proc, stdout, stderr) = cmd.run_with_output(
+        state,
+        {
+            'cmd': ['pulumi', 'stack', 'output', '--json']
+        })
+
+    return (proc.returncode == 0, stdout, stderr)
 
 
 def make():

--- a/terrat_runner/engine_pulumi.py
+++ b/terrat_runner/engine_pulumi.py
@@ -52,10 +52,10 @@ def apply(state, config):
     (proc, stdout, stderr) = cmd.run_with_output(
         state,
         {
-            'cmd': ['pulumi', 'up', '--yes']
+            'cmd': ['pulumi', 'up', '--yes', '--diff']
         })
 
-    return (proc.returncode == 0, stdout, stderr)
+    return (proc.returncode == 0, format_diff(stdout), stderr)
 
 
 def diff(state, config):

--- a/terrat_runner/engine_pulumi.py
+++ b/terrat_runner/engine_pulumi.py
@@ -66,7 +66,11 @@ def plan(state, config):
     with open(state.env['TERRATEAM_PLAN_FILE'], 'w') as f:
         f.write('{}')
 
-    return (proc.returncode == 0, stdout, stderr)
+    success = proc.returncode == 0
+    # Pulumi preview shows "to create", "to update", "to delete", "to replace" when there are changes
+    change_indicators = ['to create', 'to update', 'to delete', 'to replace']
+    has_changes = success and any(ind in stdout for ind in change_indicators)
+    return (success, has_changes, stdout, stderr)
 
 
 def unsafe_apply(state, config):

--- a/terrat_runner/results_compat.py
+++ b/terrat_runner/results_compat.py
@@ -190,6 +190,34 @@ def workflow_step_transform_to_1(result):
             },
             'outputs': output_text_transform_to_1(result)
         }
+    elif step == 'pulumi/plan':
+        return {
+            'success': success(result),
+            'workflow_step': {
+                'type': 'plan'
+            },
+            'outputs': (output_plan_transform_to_1(result)
+                        if result['success']
+                        else output_text_transform_to_1(result))
+        }
+    elif step == 'pulumi/apply':
+        return {
+            'success': success(result),
+            'workflow_step': {
+                'type': 'apply'
+            },
+            'outputs': output_text_transform_to_1(result)
+        }
+    elif step == 'pulumi/init':
+        return {
+            'success': success(result),
+            'workflow_step': {
+                'type': 'run',
+                'cmd': result['payload'].get('cmd', ['pulumi', 'init']),
+                'exit_code': result['payload'].get('exit_code')
+            },
+            'outputs': output_text_transform_to_1(result)
+        }
     else:
         raise Exception('Unknown output step: {}'.format(step))
 

--- a/terrat_runner/results_compat.py
+++ b/terrat_runner/results_compat.py
@@ -217,7 +217,7 @@ def transform_to_1(state, results):
                         if o['scope'] == {'type': 'run', 'flow': 'hooks', 'subflow': 'pre'}],
                 'post': [workflow_step_transform_to_1(o) for o in results['steps']
                          if o['scope'] == {'type': 'run', 'flow': 'hooks', 'subflow': 'post'}]
-            },
+                },
         },
         'dirspaces': [dirspace_transform_to_1(steps[0]['scope'], steps)
                       for steps in dirspaces.values()]

--- a/terrat_runner/results_compat.py
+++ b/terrat_runner/results_compat.py
@@ -190,34 +190,6 @@ def workflow_step_transform_to_1(result):
             },
             'outputs': output_text_transform_to_1(result)
         }
-    elif step == 'pulumi/plan':
-        return {
-            'success': success(result),
-            'workflow_step': {
-                'type': 'plan'
-            },
-            'outputs': (output_plan_transform_to_1(result)
-                        if result['success']
-                        else output_text_transform_to_1(result))
-        }
-    elif step == 'pulumi/apply':
-        return {
-            'success': success(result),
-            'workflow_step': {
-                'type': 'apply'
-            },
-            'outputs': output_text_transform_to_1(result)
-        }
-    elif step == 'pulumi/init':
-        return {
-            'success': success(result),
-            'workflow_step': {
-                'type': 'run',
-                'cmd': result['payload'].get('cmd', ['pulumi', 'init']),
-                'exit_code': result['payload'].get('exit_code')
-            },
-            'outputs': output_text_transform_to_1(result)
-        }
     else:
         raise Exception('Unknown output step: {}'.format(step))
 
@@ -245,7 +217,7 @@ def transform_to_1(state, results):
                         if o['scope'] == {'type': 'run', 'flow': 'hooks', 'subflow': 'pre'}],
                 'post': [workflow_step_transform_to_1(o) for o in results['steps']
                          if o['scope'] == {'type': 'run', 'flow': 'hooks', 'subflow': 'post'}]
-                },
+            },
         },
         'dirspaces': [dirspace_transform_to_1(steps[0]['scope'], steps)
                       for steps in dirspaces.values()]


### PR DESCRIPTION
Fixes two bugs that made the Pulumi engine non-functional with Terrateam

### Bug 1: Plan output not displayed in PR comments

`diff()` returned `None`, so `diff_stdout` was always empty and the plan payload contained no output. Now `plan()` saves the `pulumi preview --diff` stdout to `<plan_file>.diff` and `diff()` reads it back — matching how the Terraform engine provides plan output via `terraform show`.

Before: *(blank plan output in PR comment)*

After: *(attribute-level diff with GitHub syntax highlighting)*

### Bug 2: Missing `has_changes` return value

`plan()` returned 3 values `(success, stdout, stderr)` but the runner unpacks 4 `(success, has_changes, stdout, stderr)`, causing a runtime crash on every plan. Now detects changes by checking for Pulumi's change indicators (`to create`, `to update`, `to delete`, `to replace`) in the preview output.

### Additional improvements

- `--diff` flag added to `pulumi preview` for attribute-level output
- `--diff` flag added to `pulumi up` with `format_diff()` applied so apply output is better formatted/informative - syntax highlighting does not apply here
- Implemented `diff_json()`, `outputs()` which were stubs returning `None`
- `format_diff()` helper moves `+`/`-`/`~` markers to start-of-line for GitHub ` ```diff ` coloring

### How to Test
I ran through all these in my setup, but this is how to test the changes directly

- [ ] Trigger a plan — verify PR comment shows preview output with colored diff
- [ ] Trigger an apply — verify output now provides structured created/updated/destroyed list
- [ ] Verify no-op plan correctly reports `has_changes=False` and doesn't prompt for apply


### Before
<img width="896" height="826" alt="image" src="https://github.com/user-attachments/assets/b8df50da-f469-41b5-ac49-889eae5960c2" />


### After

#### No Changes
<img width="885" height="926" alt="image" src="https://github.com/user-attachments/assets/886523e8-be7b-468e-8cef-36bfab850548" />

#### Changes
<img width="876" height="1518" alt="image" src="https://github.com/user-attachments/assets/08917553-38b3-48fa-9646-bb3234f235fc" />