### PR TITLE
fix: tree builder env template substitution bug

### DIFF
--- a/terrat_runner/cmd.py
+++ b/terrat_runner/cmd.py
@@ -7,10 +7,6 @@ import subprocess
 import sys
 
 
-class MissingEnvVar(Exception):
-    pass
-
-
 def _strip_ansi(s):
     return re.sub(r'\033\[(\d|;)+?m', '', s)
 

--- a/terrat_runner/cmd.py
+++ b/terrat_runner/cmd.py
@@ -15,15 +15,17 @@ def _strip_ansi(s):
     return re.sub(r'\033\[(\d|;)+?m', '', s)
 
 
-def replace_vars(s, env):
+def replace_vars(value, env):
+    tmpl = string.Template(value)
     try:
-        v = string.Template(s).substitute(env)
-        if s == v:
-            return v
-        else:
-            return replace_vars(v, env)
-    except KeyError as exn:
-        raise MissingEnvVar(*exn.args)
+        result = tmpl.substitute(env)
+    except (KeyError, ValueError):
+        logging.warning('REPLACE_VARS : unresolved variable in: %s', value)
+        result = tmpl.safe_substitute(env)
+    if value == result:
+        return result
+    else:
+        return replace_vars(result, env)
 
 
 def _create_env(env, additional_env):

--- a/terrat_runner/work_build_tree.py
+++ b/terrat_runner/work_build_tree.py
@@ -68,7 +68,6 @@ def run(state):
 
         try:
             env = {'TERRATEAM_BASE_REF': state.work_manifest['base_ref']}
-            env.update(state.env)
             (proc, stdout, stderr) = cmd.run_with_output(
                 state,
                 {

--- a/terrat_runner/work_build_tree.py
+++ b/terrat_runner/work_build_tree.py
@@ -68,6 +68,7 @@ def run(state):
 
         try:
             env = {'TERRATEAM_BASE_REF': state.work_manifest['base_ref']}
+            env.update(state.env)
             (proc, stdout, stderr) = cmd.run_with_output(
                 state,
                 {

--- a/terrat_runner/workflow_step_run.py
+++ b/terrat_runner/workflow_step_run.py
@@ -45,17 +45,6 @@ def run(state, config):
                              state=state,
                              step='run',
                              success=success)
-    except cmd.MissingEnvVar as exn:
-        logging.error('Missing environment variable: %s', exn.args[0])
-        payload = {
-            'cmd': config['cmd'],
-            'text': 'ERROR: Missing environment variable: {}'.format(exn.args[0]),
-            'visible_on': visible_on
-        }
-        return workflow.make(payload=payload,
-                             state=state,
-                             step='run',
-                             success=False)
     except FileNotFoundError:
         logging.exception('Could not find program to run %r', config['cmd'])
         payload = {


### PR DESCRIPTION
The build-tree step crashes if any environment variable value contains a Python string.Template pattern (e.g., $github or $foo).

I tracked down the root cause to be due to this:

1. The env variables are populated with the entire state.env in [this](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/work_build_tree.py#L71) line, which is then passed to [cmd.run_with_output()](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/work_build_tree.py#L77) as config.env
2. [run_with_output() calls](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/cmd.py#L64) _create_env() to merge state.env and config.env (which now already contains state.env)
3. _create_env() calls [replace_vars()](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/cmd.py#L32) which does a [simple template string substitution](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/cmd.py#L20)


Now since state.env is being merged twice, once [here](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/work_build_tree.py#L71) and again [here](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/cmd.py#L64), if any env var contains an unintended template string, it would try to find the value of for that key and crash. In our case, somebody updated an org wide secret HARBOR_CACHE_DOCKER_USERNAME=robot$github-actions-rw . Since it contained $github, all our terrateam workflows started failing with a cryptic error.

<img width="1864" height="514" alt="image" src="https://github.com/user-attachments/assets/99b51b1c-de80-4d1d-bb22-cde590c1b8a9" />

The fix is to remove [this line](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/work_build_tree.py#L71) to just pass in [TERRATEAM_BASE_REF](https://github.com/terrateamio/action/blob/31970f516f9644d7f0b93c9c1a4b85864607b609/terrat_runner/work_build_tree.py#L70) alone for substitution. We've implemented this in a fork and it has been working without regressions.

Accompanying slack thread: https://terrateamio.slack.com/archives/C02GDJFTZ2Q/p1774934862961129?thread_ts=1774934361.913649&cid=C02GDJFTZ2Q