### PR TITLE
fix(infracost): set skip_autodetect to avoid duplicate projects in monorepos

### DIFF
--- a/terrat_runner/infracost.py
+++ b/terrat_runner/infracost.py
@@ -24,6 +24,12 @@ def create_infracost_yml(outname, dirspaces):
             {
                 'path': ds['path'],
                 'terraform_workspace': ds['workspace'],
+                # Treat each dirspace as exactly one project. Without this,
+                # Infracost autodetect scans within every `path`, and a root
+                # dirspace (`path: .`) recursively re-discovers every nested
+                # module in a monorepo. Those collide with the explicit leaf
+                # entries -> "duplicate project name" -> `infracost diff` aborts.
+                'skip_autodetect': True,
             }
             for ds in dirspaces
         ]


### PR DESCRIPTION
`create_infracost_yml` emitted each dirspace as {path, terraform_workspace} with autodetect left on. Infracost then scans within every `path`, so a root dirspace (`path: .`) recursively re-discovers every nested root module in a monorepo. Those duplicate the explicit leaf entries, and `infracost diff --compare-to` aborts with "duplicate project name" (see infracost/infracost#1952), breaking cost estimation for the whole run.

Set skip_autodetect: true on each generated project so each path maps to exactly one project — which matches Terrateam's model of one dirspace = one Terraform root.

```bash
cwd=/github/workspace: stderr: Update: A new version of Infracost is available: v0.10.42 → v0.10.44
cwd=/github/workspace: stderr:   $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
DEBUG:root:INFRACOST : RETRY_TEST : ['infracost', 'breakdown', '--config-file=/tmp/tmpu88e_923/infracost/config.yml', '--format=json', '--out-file=/tmp/tmpu88e_923/infracost/infracost.json']
DEBUG:root:CMD : cmd=['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json'] : cwd=/github/workspace
cwd=/github/workspace: stderr: Error: Invalid --compare-to Infracost JSON, found duplicate project name company/terraform/aws/staging (Module path: aws/staging)
cwd=/github/workspace: stderr: 
cwd=/github/workspace: stderr: Update: A new version of Infracost is available: v0.10.42 → v0.10.44
cwd=/github/workspace: stderr:   $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
DEBUG:root:INFRACOST : RETRY_TEST : ['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json']
DEBUG:root:CMD : cmd=['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json'] : cwd=/github/workspace
cwd=/github/workspace: stderr: Error: Invalid --compare-to Infracost JSON, found duplicate project name company/terraform/aws/staging (Module path: aws/staging)
cwd=/github/workspace: stderr: 
cwd=/github/workspace: stderr: Update: A new version of Infracost is available: v0.10.42 → v0.10.44
cwd=/github/workspace: stderr:   $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
DEBUG:root:INFRACOST : RETRY_TEST : ['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json']
DEBUG:root:CMD : cmd=['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json'] : cwd=/github/workspace
cwd=/github/workspace: stderr: Error: Invalid --compare-to Infracost JSON, found duplicate project name company/terraform/aws/staging (Module path: aws/staging)
cwd=/github/workspace: stderr: 
cwd=/github/workspace: stderr: Update: A new version of Infracost is available: v0.10.42 → v0.10.44
cwd=/github/workspace: stderr:   $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
ERROR:root:INFRACOST : ERROR
Traceback (most recent call last):
  File "/terrat_runner/workflow_step_infracost_setup.py", line 147, in run
    _run_retry(state,
    ~~~~~~~~~~^^^^^^^
               ['infracost',
               ^^^^^^^^^^^^^
    ...<3 lines>...
                '--compare-to={}'.format(prev_infracost),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                '--out-file={}'.format(diff_infracost)])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/terrat_runner/workflow_step_infracost_setup.py", line 34, in _run_retry
    raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=c, output=stdout)
subprocess.CalledProcessError: Command '['infracost', 'diff', '--format=json', '--path=/tmp/tmpu88e_923/infracost/infracost.json', '--compare-to=/tmp/tmpu88e_923/infracost/infracost-prev.json', '--out-file=/tmp/tmpu88e_923/infracost/infracost-diff.json']' returned non-zero exit status 1.
```