### PR TITLE
terrateamio/terrateam#1339 Bake ansible into the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1776595483
+ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1781682162
 FROM ${BASE_IMAGE}
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -70,6 +70,16 @@ RUN python3 -m venv /opt/checkov && \
     /opt/checkov/bin/pip install checkov==${CHECKOV_VERSION} && \
     ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov
 
+# ansible (and pywinrm for managing Windows hosts over WinRM) is baked in so
+# runs don't pay a runtime pip install. The proxy/bin/ansible-playbook shim
+# swaps to a different ansible-core version at runtime if ANSIBLE_VERSION is
+# overridden, mirroring how checkov/conftest are handled.
+ENV ANSIBLE_VERSION=2.20.3
+RUN python3 -m venv /opt/ansible && \
+    /opt/ansible/bin/pip install ansible-core==${ANSIBLE_VERSION} ansible pywinrm && \
+    ln -s /opt/ansible/bin/ansible-galaxy /usr/local/bin/ansible-galaxy && \
+    ln -s /opt/ansible/bin/ansible-playbook /usr/local/bin/ansible-playbook
+
 ENV RESOURCELY_VERSION=1.0.45
 
 COPY ./bin/ /usr/local/bin

--- a/proxy/bin/ansible-playbook
+++ b/proxy/bin/ansible-playbook
@@ -3,18 +3,21 @@
 set -e
 set -u
 
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-}"
+# ansible-core is baked into /opt/ansible (see Dockerfile.base). Default to that
+# version; if the caller pins a different ANSIBLE_VERSION, swap the venv to it at
+# runtime. Same pattern as proxy/bin/checkov and proxy/bin/conftest.
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.20.3}"
+ANSIBLE_VENV=/opt/ansible
 
-if [ -f /usr/local/bin/ansible-playbook ]; then
-    exec /usr/local/bin/ansible-playbook "$@"
+if [[ ! -x "${ANSIBLE_VENV}/bin/ansible-playbook" ]]; then
+    flock /tmp/ansible-playbook-install \
+        bash -c "python3 -m venv '${ANSIBLE_VENV}' && '${ANSIBLE_VENV}/bin/pip' install 'ansible-core==${ANSIBLE_VERSION}' ansible pywinrm" 1>&2
 else
-    if [[ -n "$ANSIBLE_VERSION" ]]; then
-        flock /tmp/ansible-playbook-install pip install "ansible-core==$ANSIBLE_VERSION" ansible 1>&2
-    else
-        flock /tmp/ansible-playbook-install pip install ansible 1>&2
+    INSTALLED_VERSION=$("${ANSIBLE_VENV}/bin/ansible-playbook" --version 2>/dev/null | grep -oP 'core \K[0-9.]+' | head -n1 || echo "")
+    if [[ "${INSTALLED_VERSION}" != "${ANSIBLE_VERSION}" ]]; then
+        flock /tmp/ansible-playbook-install \
+            "${ANSIBLE_VENV}/bin/pip" install --upgrade "ansible-core==${ANSIBLE_VERSION}" ansible pywinrm 1>&2
     fi
-    # We're installing pywinrm globally for $CUSTOMER, despite best practices.
-    # This should be removed once they start building their own image.
-    flock /tmp/pywinrm-install pip install pywinrm
-    exec /usr/local/bin/ansible-playbook "$@"
 fi
+
+exec "${ANSIBLE_VENV}/bin/ansible-playbook" "$@"


### PR DESCRIPTION
Install ansible-core (+ the ansible community packages and pywinrm for managing Windows hosts over WinRM) into a dedicated venv in Dockerfile.base so runs no longer pay a runtime pip install for ansible.

Rewrite proxy/bin/ansible-playbook to the same version-aware pattern used by proxy/bin/checkov and proxy/bin/conftest: use the baked-in ansible-core by default, and only reinstall at runtime when the caller pins a different ANSIBLE_VERSION. This keeps version-pinning users working while making ansible available out of the box for everyone.

This removes the previous per-customer hack that pip-installed pywinrm globally at runtime.