### PR TITLE
Revert ansible & oci bake-in (moved to customer-b1720-trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1781682162
+ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1776595483
 FROM ${BASE_IMAGE}
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -70,16 +70,6 @@ RUN python3 -m venv /opt/checkov && \
     /opt/checkov/bin/pip install checkov==${CHECKOV_VERSION} && \
     ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov
 
-# ansible (and pywinrm for managing Windows hosts over WinRM) is baked in so
-# runs don't pay a runtime pip install. The proxy/bin/ansible-playbook shim
-# swaps to a different ansible-core version at runtime if ANSIBLE_VERSION is
-# overridden, mirroring how checkov/conftest are handled.
-ENV ANSIBLE_VERSION=2.20.3
-RUN python3 -m venv /opt/ansible && \
-    /opt/ansible/bin/pip install ansible-core==${ANSIBLE_VERSION} ansible pywinrm && \
-    ln -s /opt/ansible/bin/ansible-galaxy /usr/local/bin/ansible-galaxy && \
-    ln -s /opt/ansible/bin/ansible-playbook /usr/local/bin/ansible-playbook
-
 ENV RESOURCELY_VERSION=1.0.45
 
 COPY ./bin/ /usr/local/bin

--- a/proxy/bin/ansible-playbook
+++ b/proxy/bin/ansible-playbook
@@ -3,21 +3,18 @@
 set -e
 set -u
 
-# ansible-core is baked into /opt/ansible (see Dockerfile.base). Default to that
-# version; if the caller pins a different ANSIBLE_VERSION, swap the venv to it at
-# runtime. Same pattern as proxy/bin/checkov and proxy/bin/conftest.
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.20.3}"
-ANSIBLE_VENV=/opt/ansible
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-}"
 
-if [[ ! -x "${ANSIBLE_VENV}/bin/ansible-playbook" ]]; then
-    flock /tmp/ansible-playbook-install \
-        bash -c "python3 -m venv '${ANSIBLE_VENV}' && '${ANSIBLE_VENV}/bin/pip' install 'ansible-core==${ANSIBLE_VERSION}' ansible pywinrm" 1>&2
+if [ -f /usr/local/bin/ansible-playbook ]; then
+    exec /usr/local/bin/ansible-playbook "$@"
 else
-    INSTALLED_VERSION=$("${ANSIBLE_VENV}/bin/ansible-playbook" --version 2>/dev/null | grep -oP 'core \K[0-9.]+' | head -n1 || echo "")
-    if [[ "${INSTALLED_VERSION}" != "${ANSIBLE_VERSION}" ]]; then
-        flock /tmp/ansible-playbook-install \
-            "${ANSIBLE_VENV}/bin/pip" install --upgrade "ansible-core==${ANSIBLE_VERSION}" ansible pywinrm 1>&2
+    if [[ -n "$ANSIBLE_VERSION" ]]; then
+        flock /tmp/ansible-playbook-install pip install "ansible-core==$ANSIBLE_VERSION" ansible 1>&2
+    else
+        flock /tmp/ansible-playbook-install pip install ansible 1>&2
     fi
+    # We're installing pywinrm globally for $CUSTOMER, despite best practices.
+    # This should be removed once they start building their own image.
+    flock /tmp/pywinrm-install pip install pywinrm
+    exec /usr/local/bin/ansible-playbook "$@"
 fi
-
-exec "${ANSIBLE_VENV}/bin/ansible-playbook" "$@"

--- a/proxy/bin/oci
+++ b/proxy/bin/oci
@@ -3,18 +3,10 @@
 set -e
 set -u
 
-# oci-cli is large, so it's installed on first use rather than baked into the
-# base image. It must go in a venv: a raw `pip install` fails on Debian trixie
-# (PEP 668 externally-managed-environment). The venv persists for the life of
-# the container, so subsequent invocations exec it directly.
-OCI_VENV=/opt/oci
-
 if [ -f /usr/local/bin/oci ]; then
     exec /usr/local/bin/oci "$@"
-elif [ -x "${OCI_VENV}/bin/oci" ]; then
-    exec "${OCI_VENV}/bin/oci" "$@"
 else
-    flock /tmp/oci-cli-install \
-        bash -c "python3 -m venv '${OCI_VENV}' && '${OCI_VENV}/bin/pip' install oci-cli" 1>&2
-    exec "${OCI_VENV}/bin/oci" "$@"
+    flock /tmp/oci-cli-install pip install oci-cli 1>&2
+    exec /usr/local/bin/oci "$@"
 fi
+


### PR DESCRIPTION
Reverts the ansible and oci changes from `main`. These were built for a customer and are too big for `main`, so they now live on the `customer-b1720-trixie` branch instead.

Reverts:
- terrateamio/terrateam#1339 Bake ansible into the base image (a401fdc)
- terrateamio/terrateam#1340 FIX oci cli (0d7c355)

The unrelated #1305 (base ref value to environment) is left untouched.

The reverted changes have been reapplied on `customer-b1720-trixie`, whose tree is identical to current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)