### PR TITLE
ADD TERRATEAM_LOG_LEVEL env var to control runner log level

### DIFF
--- a/terrat_runner/main.py
+++ b/terrat_runner/main.py
@@ -328,7 +328,10 @@ def run(args, env):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    log_level = os.environ.get('TERRATEAM_LOG_LEVEL', 'DEBUG').upper()
+    if log_level not in ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']:
+        log_level = 'DEBUG'
+    logging.basicConfig(level=log_level)
 
     print(BANNER)
     print('*** These are not the logs you are looking for ***')

--- a/terrat_runner/workflow_step_infracost_setup.py
+++ b/terrat_runner/workflow_step_infracost_setup.py
@@ -157,7 +157,7 @@ def run(state, config):
                 diff = json.load(f)
 
             logging.info('INFRACOST : DIFF')
-            logging.info('%s', json.dumps(diff, indent=2))
+            logging.debug('%s', json.dumps(diff, indent=2))
 
             try:
                 dirspaces = [


### PR DESCRIPTION
The runner hardcodes logging.basicConfig(level=logging.DEBUG), and the Infracost diff JSON is logged at INFO with indent=2. On monorepos with many directories this makes even a single-directory plan produce 50k+ log lines (the Infracost diff alone was 54k lines on ours), which makes the action output unreadable.

- Read the root log level from `TERRATEAM_LOG_LEVEL` (default `DEBUG`, so behavior is unchanged unless the workflow opts in). Invalid values fall back to `DEBUG` rather than raising.
- Demote the Infracost diff JSON payload to logging.debug; the `INFRACOST : DIFF` marker stays at INFO.

Workflows can now set `TERRATEAM_LOG_LEVEL: INFO` on the action step to get concise logs, and flip back to DEBUG when debugging an issue.