### PR TITLE
terrateamio/terrateam#1382 FIX Use --detailed-exitcode for stategraph engine plan has_changes

### DIFF
--- a/terrat_runner/engine_stategraph.py
+++ b/terrat_runner/engine_stategraph.py
@@ -29,10 +29,13 @@ def plan(state, config):
     logging.info('PLAN : %s : engine=stategraph', state.path)
     plan_cmd = ['stategraph', 'tf', 'plan',
                 '--out', '${TERRATEAM_PLAN_FILE}',
+                '--detailed-exitcode',
                 '--workspace', state.workspace]
     plan_cmd += config.get('extra_args', [])
-    (success, stdout, stderr) = _run(state, plan_cmd)
-    has_changes = success and 'No changes detected.' not in stdout
+    (proc, stdout, stderr) = cmd.run_with_output(state, {'cmd': plan_cmd})
+    # --detailed-exitcode: 0 = no changes, 2 = changes, anything else = error.
+    success = proc.returncode in [0, 2]
+    has_changes = proc.returncode == 2
     return (success, has_changes, stdout, stderr)
 
 


### PR DESCRIPTION
Fixes the Stategraph engine `has_changes` detection in the runner.

`engine_stategraph.py` computed `has_changes` by string-matching stdout for OpenTofu's `No changes detected.`, which the Stategraph CLI does not emit. As a result a plan that reports `Plan: N to add` was stored with `has_changes = false`, and the MR notifications summary + dirspace header showed "No changes" despite there being a change.

Switch to `stategraph tf plan --detailed-exitcode` (0 = no changes, 2 = changes; semantics fixed in stategraph/stategraph#927) and derive `success`/`has_changes` from the exit code, mirroring `engine_tf.py`. Same plan invocation — no extra plan run. Also fixes a latent bug where, once `--detailed-exitcode` is set, exit code 2 would be treated as a failure by the old `success = returncode == 0` logic.

Ref: terrateamio/terrateam#1382
