### PR TITLE
terrateamio/terrateam#1214 ADD exact resource-change counts to plan output

### DIFF
--- a/terrat_runner/engine_stategraph.py
+++ b/terrat_runner/engine_stategraph.py
@@ -3,6 +3,7 @@ import os
 
 import cmd
 import engine
+import engine_tf
 
 
 def _run(state, cmd_list):
@@ -44,7 +45,24 @@ def diff(state, config):
 
 
 def diff_json(state, config):
-    return None
+    # `stategraph tf show --json PLAN` emits the plan as a standard
+    # `terraform show -json` document (resource_changes), so the server can
+    # compute exact change counts.  The API base and credentials come from the
+    # STATEGRAPH_* environment.
+    logging.info('DIFF_JSON : %s : engine=stategraph', state.path)
+    (proc, stdout, stderr) = cmd.run_with_output(
+        state,
+        {
+            'cmd': ['stategraph', 'tf', 'show', '--json', '${TERRATEAM_PLAN_FILE}']
+        })
+
+    if proc.returncode == 0:
+        doc = engine_tf.parse_show_json(stdout)
+        if doc is not None:
+            return (True, doc)
+        return (False, stdout, 'could not parse stategraph tf show --json output')
+
+    return (False, stdout, stderr)
 
 
 def apply(state, config):

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -19,6 +19,34 @@ def format_diff(text):
     return s
 
 
+def parse_show_json(stdout):
+    """Parse the JSON document produced by `<tf> show -json`.
+
+    `terraform show -json` prints a single compact JSON object.  Wrappers such
+    as terragrunt can, depending on version and configuration, emit their own
+    log lines on stdout around it.  Parse the whole output first, then fall
+    back to the line that is the terraform show document.  Returns None if no
+    such document is found (the caller then reports no counts rather than
+    guessing)."""
+    try:
+        return json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith('{'):
+            continue
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(doc, dict) and ('resource_changes' in doc or 'format_version' in doc):
+            return doc
+
+    return None
+
+
 class Engine:
     def __init__(self, name, override_tf_cmd, **options):
         self.name = name
@@ -135,10 +163,10 @@ class Engine:
             })
 
         if proc.returncode == 0:
-            try:
-                return (True, json.loads(stdout))
-            except json.JSONDecodeError as exn:
-                return (False, stdout, str(exn))
+            doc = parse_show_json(stdout)
+            if doc is not None:
+                return (True, doc)
+            return (False, stdout, 'could not parse show -json output')
 
         return (False, stdout, stderr)
 

--- a/terrat_runner/workflow_step_plan.py
+++ b/terrat_runner/workflow_step_plan.py
@@ -17,6 +17,46 @@ ACCESS_KEY_ID = 'access_key_id'
 SECRET_ACCESS_KEY = 'secret_access_key'
 
 
+def _resource_summary(diff_json):
+    """Compute exact resource-change counts from a ``terraform show -json``
+    document.  Returns ``None`` when the document is not in that shape (for
+    example a Pulumi or custom engine that does not emit ``resource_changes``),
+    in which case the server falls back to parsing the plan text."""
+    if not isinstance(diff_json, dict):
+        return None
+
+    resource_changes = diff_json.get('resource_changes')
+    if not isinstance(resource_changes, list):
+        return None
+
+    created = updated = deleted = replaced = imported = 0
+    for rc in resource_changes:
+        change = rc.get('change') or {}
+        actions = set(change.get('actions') or [])
+
+        if change.get('importing'):
+            imported += 1
+
+        if actions == {'create'}:
+            created += 1
+        elif actions == {'update'}:
+            updated += 1
+        elif actions == {'delete'}:
+            deleted += 1
+        elif actions == {'create', 'delete'}:
+            # A replacement is reported as create+delete in either order.
+            replaced += 1
+        # 'no-op' and 'read' do not represent a pending change.
+
+    return {
+        'created': created,
+        'updated': updated,
+        'deleted': deleted,
+        'replaced': replaced,
+        'imported': imported,
+    }
+
+
 def _store_plan_data(plan_data, work_token, api_base_url, dir_path, workspace, has_changes):
     plan_data = base64.b64encode(json.dumps(plan_data).encode('utf-8')).decode('utf-8')
 
@@ -196,21 +236,21 @@ def run(state, config):
             step=state.engine.name + '/plan',
             success=success)
 
-    # res = state.engine.diff_json(state, config)
-    # if res and res[0]:
-    #     (success, diff_json) = res
-    # elif res:
-    #     (success, stdout, stderr) = res
-    #     return workflow.Result2(
-    #         payload={
-    #             'text': '\n'.join([stderr, stdout]),
-    #             'visible_on': 'always',
-    #         },
-    #         state=state,
-    #         step=state.engine.name + '/plan',
-    #         success=success)
-    # else:
-    #     diff_json = None
+    # Best-effort exact resource-change counts from the machine-readable plan.
+    # Never fail the plan over this: engines that do not emit a
+    # terraform-style document simply yield no summary and the server falls
+    # back to parsing the plan text.
+    resource_summary = None
+    diff_json_fn = getattr(state.engine, 'diff_json', None)
+    if diff_json_fn is not None:
+        try:
+            res = state.engine.diff_json(state, config)
+            if res and res[0]:
+                resource_summary = _resource_summary(res[1])
+        except Exception:
+            logging.exception('PLAN : RESOURCE_SUMMARY_FAILED : %s : %s',
+                              state.env['TERRATEAM_DIR'],
+                              state.env['TERRATEAM_WORKSPACE'])
 
     plan_storage = rc.get_plan_storage(state.repo_config)
 
@@ -242,14 +282,17 @@ def run(state, config):
                  state.env['TERRATEAM_WORKSPACE'],
                  has_changes)
 
+    payload = {
+        'plan': diff_stdout,
+        'has_changes': has_changes,
+        'text': stdout,
+        'visible_on': 'always',
+    }
+    if resource_summary is not None:
+        payload['resource_summary'] = resource_summary
+
     return workflow.Result2(
-        payload={
-            'plan': diff_stdout,
-            # 'diff': diff_json,
-            'has_changes': has_changes,
-            'text': stdout,
-            'visible_on': 'always',
-        },
+        payload=payload,
         state=state,
         step=state.engine.name + '/plan',
         success=True)


### PR DESCRIPTION
### Coordination update (2026-08-03)

The paired server work has been split out of the large draft PR terrateamio/terrateam#1396 into terrateamio/terrateam#1471, #1472, #1474, #1475, #1476, and #1477. This runner PR remains the sibling Phase 2 change for exact `resource_summary` counts; it should stay paired with the final unified-comment server PR/stack (ending at terrateamio/terrateam#1477) and can land after server support is merged.

Computes exact resource-change counts (`created` / `updated` / `deleted` / `replaced` / `imported`) from the engine's `terraform show -json` (`resource_changes`) and attaches them to the plan step payload as `resource_summary`. The unified-summary server PR/stack (now split across **terrateamio/terrateam#1474 → #1475 → #1476 → #1477**) reads these directly to render the unified summary comment's count columns, including `Replaced`.

**No text parsing.** Engines that don't emit a terraform-shaped plan document produce no summary, and the server renders `-` rather than a guessed number — a count is either exact or absent.

### Engine coverage
- **terraform / tofu / cdktf** — clean `show -json`; exact counts.
- **terragrunt** — `diff_json` now parses the show output robustly (`parse_show_json`): terragrunt can, depending on version/config, surround the JSON with log lines on stdout, so we parse the whole output first, else pick the line that is the terraform show document. Counts never silently vanish.
- **stategraph** — implemented `diff_json` via `stategraph tf show --json PLAN`, which emits a standard terraform show document (`resource_changes`), so stategraph now reports exact counts too. ⚠️ The stategraph proxy wrapper downloads `STATEGRAPH_VERSION` (defaults to the latest **stable** release); pin `engine.version` to match your stategraph server, otherwise `plan` can fail against a newer (rc) server.
- **pulumi / custom** — no terraform-shaped document → no summary → server shows `-`.

Paired with the unified-summary server PR/stack, now split across **terrateamio/terrateam#1474 → #1475 → #1476 → #1477**. Issue: terrateamio/terrateam#1214.

Validated live end-to-end in a test repo for terraform, terragrunt, and stategraph engines, including a real create/update/replace/delete plan, plus the runner helper unit-tested against clean and log-noisy `show` output.