### PR TITLE
Add TERRATEAM_INFRACOST_COMPACT_LOG to reduce action log volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ the following operations:
 
 The action is meant to be executed manually (via a `workflow_dispatch` event)
 rather than automatically triggered.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TERRATEAM_INFRACOST_COMPACT_LOG` | `false` | When set to `1` or `true`, replaces the full Infracost diff JSON logged to the Actions console with a single summary line (`projects`, `prev`, `curr`, `diff` monthly costs). Useful for large monorepos where the JSON output spans hundreds of thousands of lines. The full diff JSON is still computed and sent to the Terrateam API regardless of this setting. |

--- a/terrat_runner/workflow_step_infracost_setup.py
+++ b/terrat_runner/workflow_step_infracost_setup.py
@@ -182,7 +182,14 @@ def run(state, config):
                 diff = json.load(f)
 
             logging.info('INFRACOST : DIFF')
-            logging.info('%s', json.dumps(diff, indent=2))
+            if state.env.get('TERRATEAM_INFRACOST_COMPACT_LOG', '').lower() in ('1', 'true'):
+                logging.info('INFRACOST : DIFF : projects=%d prev=$%s curr=$%s diff=$%s',
+                             len(diff.get('projects', [])),
+                             diff.get('pastTotalMonthlyCost', '0'),
+                             diff.get('totalMonthlyCost', '0'),
+                             diff.get('diffTotalMonthlyCost', '0'))
+            else:
+                logging.info('%s', json.dumps(diff, indent=2))
 
             try:
                 dirspaces = [


### PR DESCRIPTION
## Problem

On large monorepos, the Infracost diff JSON logged to the Actions console can account for 90%+ of total action output — in one observed run, 480k lines out of 524k total (37 MB). This happens because `workflow_step_infracost_setup.py` logs the complete per-resource JSON breakdown for every project, including many null-valued cost fields repeated across thousands of resources.

## Solution

Add an opt-in environment variable `TERRATEAM_INFRACOST_COMPACT_LOG` that replaces the full JSON dump with a single summary log line:

```
INFRACOST : DIFF : projects=618 prev=$1234.56 curr=$1235.00 diff=$0.44
```

**Default behaviour is unchanged** — the full JSON is still logged unless `TERRATEAM_INFRACOST_COMPACT_LOG=true` (or `1`) is explicitly set. The full diff JSON is still computed and sent to the Terrateam API regardless of this setting.

## Changes

- `terrat_runner/workflow_step_infracost_setup.py` — gate the full JSON dump behind the env var
- `README.md` — document the new variable in a Configuration section

## Test plan

- [ ] Verify default behaviour (no env var set) still logs full JSON
- [ ] Set `TERRATEAM_INFRACOST_COMPACT_LOG=true` and confirm single summary line is logged
- [ ] Confirm cost estimation results sent to API are unaffected in both modes