### PR TITLE
stategraph/mono#1713 FIX report OIDC step template errors with an actionable message

### DIFF
--- a/terrat_runner/test_workflow_step_oidc.py
+++ b/terrat_runner/test_workflow_step_oidc.py
@@ -1,0 +1,89 @@
+import unittest
+
+import run_state
+import workflow_step_oidc
+
+
+def make_state(env):
+    return run_state.State(
+        api_base_url=None,
+        api_token=None,
+        engine=None,
+        env=env,
+        outputs=[],
+        path=None,
+        repo_config={},
+        result_version=1,
+        runtime=None,
+        secrets=set(),
+        sha=None,
+        success=True,
+        tmpdir=None,
+        work_manifest={},
+        work_token=None,
+        workflow=None,
+        working_dir=None,
+        workspace=None,
+    )
+
+
+class SubstTest(unittest.TestCase):
+    def test_replaces_workspace_and_stack_variables(self):
+        state = make_state({'TERRATEAM_WORKSPACE': 'production', 'environment': 'production'})
+        self.assertEqual(
+            workflow_step_oidc._subst(
+                state,
+                'projects/123/locations/global/workloadIdentityPools/pool-${environment}/providers/github'),
+            'projects/123/locations/global/workloadIdentityPools/pool-production/providers/github')
+        self.assertEqual(
+            workflow_step_oidc._subst(state, 'terrateam-${TERRATEAM_WORKSPACE}@proj.iam.gserviceaccount.com'),
+            'terrateam-production@proj.iam.gserviceaccount.com')
+
+    def test_passes_through_non_strings(self):
+        state = make_state({})
+        self.assertEqual(workflow_step_oidc._subst(state, 3600), 3600)
+
+    def test_unknown_variable_raises_template_error(self):
+        state = make_state({})
+        with self.assertRaises(workflow_step_oidc.Template_error):
+            workflow_step_oidc._subst(state, 'terrateam-${environment}@proj.iam.gserviceaccount.com')
+
+    def test_invalid_placeholder_raises_template_error(self):
+        state = make_state({})
+        with self.assertRaises(workflow_step_oidc.Template_error):
+            workflow_step_oidc._subst(state, 'trailing dollar $')
+
+
+class RunTemplateErrorTest(unittest.TestCase):
+    def test_gcp_unknown_variable_fails_with_actionable_error(self):
+        # As in hooks, where TERRATEAM_WORKSPACE and stack variables are not
+        # defined.
+        state = make_state({})
+        config = {
+            'type': 'oidc',
+            'provider': 'gcp',
+            'service_account': 'terrateam-${environment}@proj.iam.gserviceaccount.com',
+            'workload_identity_provider': 'projects/123/locations/global/workloadIdentityPools/pool/providers/github',
+        }
+        result = workflow_step_oidc.run(state, config)
+        self.assertFalse(result.success)
+        self.assertEqual(result.step, 'auth/oidc')
+        self.assertIn('environment', result.payload['text'])
+        self.assertIn('terrateam-${environment}@proj.iam.gserviceaccount.com', result.payload['text'])
+        self.assertIn('hooks', result.payload['text'])
+
+    def test_aws_unknown_variable_fails_with_actionable_error(self):
+        state = make_state({})
+        config = {
+            'type': 'oidc',
+            'provider': 'aws',
+            'role_arn': 'arn:aws:iam::123456789012:role/terrateam-${TERRATEAM_WORKSPACE}',
+        }
+        result = workflow_step_oidc.run(state, config)
+        self.assertFalse(result.success)
+        self.assertEqual(result.step, 'auth/oidc')
+        self.assertIn('TERRATEAM_WORKSPACE', result.payload['text'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/terrat_runner/workflow_step_oidc.py
+++ b/terrat_runner/workflow_step_oidc.py
@@ -32,9 +32,18 @@ class Auth_error(Exception):
     pass
 
 
+class Template_error(Exception):
+    pass
+
+
 def _subst(state, s):
     if isinstance(s, str):
-        return string.Template(s).substitute(state.env)
+        try:
+            return string.Template(s).substitute(state.env)
+        except KeyError as exn:
+            raise Template_error(s, 'unknown variable {}'.format(exn.args[0]))
+        except ValueError as exn:
+            raise Template_error(s, str(exn))
     else:
         return s
 
@@ -469,16 +478,35 @@ def run_azure(state, config):
 
 def run(state, config):
     provider = config.get('provider', 'aws')
-    if provider == 'aws':
-        return run_aws(state, config)
-    elif provider == 'azure':
-        return run_azure(state, config)
-    elif provider == 'gcp':
-        return run_gcp(state, config)
-    else:
+    try:
+        if provider == 'aws':
+            return run_aws(state, config)
+        elif provider == 'azure':
+            return run_azure(state, config)
+        elif provider == 'gcp':
+            return run_gcp(state, config)
+        else:
+            return workflow.make(
+                payload={
+                    'text': 'Unknown provider: {}'.format(config.get('provider')),
+                    'visible_on': 'error'
+                },
+                state=state,
+                step='auth/oidc',
+                success=False)
+    except Template_error as exn:
+        (value, reason) = exn.args
+        logging.error('OIDC : %s : TEMPLATE_ERROR : %s : %s', provider, value, reason)
         return workflow.make(
             payload={
-                'text': 'Unknown provider: {}'.format(config.get('provider')),
+                'text': ('Could not replace variables in the OIDC step value {value!r}: {reason}.\n'
+                         '\n'
+                         'Variables in OIDC step values are replaced from the environment.  '
+                         'TERRATEAM_DIR, TERRATEAM_WORKSPACE, TERRATEAM_STACK, and stack '
+                         'variables are only defined when the OIDC step is in a workflow\'s '
+                         'plan or apply steps, they are not defined in hooks.').format(
+                             value=value,
+                             reason=reason),
                 'visible_on': 'error'
             },
             state=state,


### PR DESCRIPTION
An unknown ${VAR} in an OIDC step value raised a bare KeyError, reported as a failed step with an empty payload. Catch template errors and fail with a message naming the value and the missing variable, noting that dirspace variables are not defined in hooks.

Verified on terrateam-demo/infrastructure#209: staging plan succeeded with substituted fields via a real WIF exchange; a stack without the variable produced the actionable message.