### PR TITLE
Pin ansible-core to 2.16.14 for Oracle Linux 8 managed nodes

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -74,7 +74,12 @@ RUN python3 -m venv /opt/checkov && \
 # runs don't pay a runtime pip install. The proxy/bin/ansible-playbook shim
 # swaps to a different ansible-core version at runtime if ANSIBLE_VERSION is
 # overridden, mirroring how checkov/conftest are handled.
-ENV ANSIBLE_VERSION=2.20.3
+#
+# 2.16 is the last ansible-core that supports Python 3.6 on the managed node
+# (see _PY3_MIN in ansible/module_utils/basic.py); 2.17 raises that to 3.7,
+# which breaks Oracle Linux 8 targets. Keep this at 2.16.x until those hosts
+# move to a newer Python. Keep proxy/bin/ansible-playbook's default in sync.
+ENV ANSIBLE_VERSION=2.16.14
 RUN python3 -m venv /opt/ansible && \
     /opt/ansible/bin/pip install ansible-core==${ANSIBLE_VERSION} ansible pywinrm && \
     ln -s /opt/ansible/bin/ansible-galaxy /usr/local/bin/ansible-galaxy && \

--- a/proxy/bin/ansible-playbook
+++ b/proxy/bin/ansible-playbook
@@ -6,7 +6,7 @@ set -u
 # ansible-core is baked into /opt/ansible (see Dockerfile.base). Default to that
 # version; if the caller pins a different ANSIBLE_VERSION, swap the venv to it at
 # runtime. Same pattern as proxy/bin/checkov and proxy/bin/conftest.
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.20.3}"
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.16.14}"
 ANSIBLE_VENV=/opt/ansible
 
 if [[ ! -x "${ANSIBLE_VENV}/bin/ansible-playbook" ]]; then


### PR DESCRIPTION
## Why

Rolling out eff6f1aa moves ansible-core from 2.15.13 (current production, bullseye base / Python 3.9) to 2.20.3. 2.20 requires Python 3.9 on the *managed* node, which breaks Oracle Linux 8 targets running Python 3.6.

## What

Pins `ANSIBLE_VERSION` to 2.16.14, and keeps the `proxy/bin/ansible-playbook` default in sync.

2.16 rather than the 2.15.7 that was requested: 2.16 is the last ansible-core that still supports Python 3.6 managed nodes, so it preserves OL8 compatibility while being two minors newer than what production runs today.

| ansible-core | control node | managed node |
|---|---|---|
| 2.15 | >=3.9 | 2.7 / 3.5+ |
| **2.16** | >=3.10 | 2.7 / **3.6+** |
| 2.17 | >=3.10 | 3.7+ |
| 2.18-2.19 | >=3.11 | 3.8+ |
| 2.20 | >=3.12 | 3.9+ |

Managed-node floors read from `_PY3_MIN` in `lib/ansible/module_utils/basic.py`; control-node floors from `Requires-Python`.

## Verification

Ran the Dockerfile layer verbatim against `debian:trixie-20260202-slim`:

- venv + `ansible-core==2.16.14 ansible pywinrm` installs clean, resolving the collections meta-package to ansible 9.13.0
- `ansible-playbook` and `ansible-galaxy` both report core 2.16.14
- playbook run (gather_facts, debug, copy, shell) passes on Python 3.13.5

Caveat: 2.16's certified control-node range is 3.10-3.12 and trixie ships 3.13, so this sits outside Ansible's supported matrix even though it works in testing.

## Known issue, not fixed here

`ANSIBLE_VERSION` cannot currently be overridden at runtime. `Dockerfile.base` symlinks `/usr/local/bin/ansible-playbook` to the baked venv, and `entrypoint.sh` *appends* `/usr/local/proxy/bin` to `PATH`, so the shim that reads the variable is shadowed:

```
ANSIBLE_VERSION=2.15.7 ansible-playbook --version  ->  core 2.20.3
```

Worth tracking separately. The baked-in pin in this PR takes effect regardless.
