### PR TITLE
Pin ansible-core to 2.15.7 to match production

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -75,11 +75,12 @@ RUN python3 -m venv /opt/checkov && \
 # swaps to a different ansible-core version at runtime if ANSIBLE_VERSION is
 # overridden, mirroring how checkov/conftest are handled.
 #
-# 2.16 is the last ansible-core that supports Python 3.6 on the managed node
-# (see _PY3_MIN in ansible/module_utils/basic.py); 2.17 raises that to 3.7,
-# which breaks Oracle Linux 8 targets. Keep this at 2.16.x until those hosts
-# move to a newer Python. Keep proxy/bin/ansible-playbook's default in sync.
-ENV ANSIBLE_VERSION=2.16.14
+# Pinned to match the ansible-core already running in production. Oracle Linux
+# 8 managed nodes ship Python 3.6, and 2.17 raises the managed-node floor to
+# 3.7 (see _PY3_MIN in ansible/module_utils/basic.py), so 2.16.x is the hard
+# ceiling here -- but stay on 2.15.x for parity until those hosts move to a
+# newer Python. Keep proxy/bin/ansible-playbook's default in sync.
+ENV ANSIBLE_VERSION=2.15.7
 RUN python3 -m venv /opt/ansible && \
     /opt/ansible/bin/pip install ansible-core==${ANSIBLE_VERSION} ansible pywinrm && \
     ln -s /opt/ansible/bin/ansible-galaxy /usr/local/bin/ansible-galaxy && \

--- a/proxy/bin/ansible-playbook
+++ b/proxy/bin/ansible-playbook
@@ -6,7 +6,7 @@ set -u
 # ansible-core is baked into /opt/ansible (see Dockerfile.base). Default to that
 # version; if the caller pins a different ANSIBLE_VERSION, swap the venv to it at
 # runtime. Same pattern as proxy/bin/checkov and proxy/bin/conftest.
-ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.16.14}"
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.15.7}"
 ANSIBLE_VENV=/opt/ansible
 
 if [[ ! -x "${ANSIBLE_VENV}/bin/ansible-playbook" ]]; then


### PR DESCRIPTION
Follow-up to #631, which pinned 2.16.14.

2.16 is the newest ansible-core that still supports Python 3.6 managed nodes, but the ask was parity with the ansible-core running in production today (2.15.13 on the bullseye base), so the customer can roll out the trixie image without also changing ansible behaviour. This drops the pin to 2.15.7.

2.16.x remains the hard ceiling for Oracle Linux 8 targets — 2.17 raises the managed-node floor to Python 3.7 — so there's headroom to move up later once parity is no longer the goal.

## Verification

Ran the Dockerfile layer verbatim against `debian:trixie-20260202-slim`:

- venv + `ansible-core==2.15.7 ansible pywinrm` installs clean, resolving the collections meta-package to ansible 8.7.0
- `ansible-playbook` and `ansible-galaxy` both report core 2.15.7
- playbook run (gather_facts, debug, copy, shell) passes on Python 3.13.5

Caveat unchanged from #631: 2.15's certified control-node range is 3.9-3.11 and trixie ships 3.13, so this is outside Ansible's supported matrix even though it works in testing.
