### PR TITLE
FIX copy bin/ so the scripts follow the ref rather than the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY terrat_runner /terrat_runner
 
 COPY proxy/bin /usr/local/proxy/bin
 
+COPY bin/ /usr/local/bin
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The scripts in `bin/` reach the image only through `Dockerfile.base`, which does `COPY ./bin/ /usr/local/bin` when the base image is built. This Dockerfile copies the entrypoints, `terrat_runner` and `proxy/bin` from the checkout, but not `bin/`, so those scripts are a property of `BASE_IMAGE` rather than of the ref being built.

The two drift apart whenever a script changes without a base image rebuild. On `v1` today `BASE_IMAGE` is pinned to `action-base:1776595483`, built 2026-04-19, while `bin/terragrunt-config-builder` beside it was last changed 2026-07-19 in 89aa32ea. The image ships a copy three months older than the source in the same tree.

The difference is not cosmetic. The April build emits no `include` or `terraform.source` file patterns at all, and reports nothing about it — the parsing phase logs its start line, then the next phase's, with no output in between for any unit:

```
[INFO] Phase 3: Parsing file patterns from HCL files...
[INFO] Phase 4: Generating Terrateam configuration...
```

Only the dependency graph survives, because that comes from `terragrunt list` rather than from parsing, so `depends_on` looks correct and the missing file patterns are easy to miss entirely.

- `COPY bin/ /usr/local/bin`, so the scripts track the ref like everything else in this Dockerfile.
- The base image keeps providing them for anything building `FROM` it directly, unchanged.

## Validation

Compared on the same commit of a private monorepo of 29 Terragrunt units, before and after this change:

| | before | after |
|---|---|---|
| includes resolved | 0 | 51 |
| units tracking the parent config they include | 0 / 28 | 28 / 28 |
| `depends_on` edges | 4 | 4 (unchanged) |

Before, a pull request editing a shared module selected a directory with no `terragrunt.hcl` and failed with `You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file`, while the units that deploy that module were never selected. After, the units are selected and the plan succeeds.

`Installing python-hcl2==7.3.1` also runs as intended once the current script is in the image; the April build has no venv fallback and instead logs `python-hcl2 not installed. Cannot parse ...` once per unit.

I could not find an existing issue for this, so the title carries no issue number.
