### PR TITLE
FIX resolve the modules a unit deploys when terraform.source comes from an include

### DIFF
--- a/bin/terragrunt-config-builder
+++ b/bin/terragrunt-config-builder
@@ -705,11 +705,89 @@ def find_parent_configs(base_dir: str) -> List[str]:
     return parent_configs
 
 
+# A module is reached once for every unit that deploys something wrapping it, so the
+# files are parsed once per directory rather than once per unit.
+module_sources_cache = {}
+
+
+def collect_module_closure(root_path: str, sources: Iterable[str]) -> Set[str]:
+    """
+    Expand module paths with the modules those modules use.
+
+    A module that wraps another is changed by an edit to either, so a unit tracking the
+    outer module has to track the inner one as well. Only local sources are followed,
+    since a module referring to a registry or git source does not make those files part
+    of the repository.
+
+    Args:
+        root_path: Root directory of the repository
+        sources: Module paths relative to the repository root
+
+    Returns:
+        Every module path reachable from sources, including sources
+    """
+    try:
+        ensure_hcl2()
+        import hcl2
+        import lark
+    except (ImportError, subprocess.CalledProcessError) as e:
+        log(f"Could not install python-hcl2. Cannot expand module sources: {e}", "ERROR")
+        return set(sources)
+
+    seen = set()
+    pending = list(sources)
+
+    while pending:
+        directory = pending.pop()
+        if directory in seen:
+            continue
+
+        seen.add(directory)
+
+        cache_key = (root_path, directory)
+        if cache_key in module_sources_cache:
+            pending.extend(module_sources_cache[cache_key])
+            continue
+
+        found = set()
+        module_sources_cache[cache_key] = found
+
+        try:
+            names = sorted(os.listdir(os.path.join(root_path, directory)))
+        except OSError:
+            continue
+
+        for name in names:
+            if not name.endswith('.tf'):
+                continue
+
+            try:
+                with open(os.path.join(root_path, directory, name)) as f:
+                    parsed = hcl2.load(f)
+            except (OSError, lark.exceptions.LarkError) as e:
+                log(f"Cannot parse {directory}/{name}: {e}", "WARN")
+                continue
+
+            for module_block in iter_hcl_blocks(parsed.get('module', [])):
+                source = hcl_string(module_block.get('source'))
+                if not source:
+                    continue
+
+                resolved = resolve_source_path(directory, source)
+                if resolved:
+                    found.add(resolved)
+
+        pending.extend(found)
+
+    return seen
+
+
 def generate_terrateam_config(
     input_config: Dict,
     terragrunt_dirs: List[str],
     all_dependencies: Dict[str, Dict],
-    dependency_graph: Dict[str, List[str]]
+    dependency_graph: Dict[str, List[str]],
+    root_path: str
 ) -> Dict:
     """
     Generate Terrateam configuration with dirs entries for each terragrunt directory.
@@ -743,8 +821,8 @@ def generate_terrateam_config(
         for include in deps.get("includes", []):
             file_patterns.append(include)
 
-        # Add local terraform module sources
-        for source in deps.get("terraform_sources", []):
+        # Add local terraform module sources, and the modules they use in turn
+        for source in sorted(collect_module_closure(root_path, deps.get("terraform_sources", []))):
             # Add glob pattern for all .tf files in the module
             file_patterns.append(f"{source}/**/*.tf")
 
@@ -828,7 +906,8 @@ def main():
             input_config,
             terragrunt_dirs,
             all_dependencies,
-            dependency_graph
+            dependency_graph,
+            repo_root
         )
 
         # Output final config to stdout

--- a/bin/terragrunt-config-builder
+++ b/bin/terragrunt-config-builder
@@ -18,7 +18,7 @@ import os
 import sys
 import subprocess
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Set
 import re
 
 
@@ -426,7 +426,7 @@ def resolve_include_path(base_dir: str, path_value: str, root_path: str) -> Opti
     return resolve_relative_path(base_dir, path_value)
 
 
-def parse_terragrunt_dependencies(file_path: str, base_dir: str, root_path: Optional[str] = None) -> Dict[str, List[str]]:
+def parse_terragrunt_dependencies(file_path: str, base_dir: str, root_path: Optional[str] = None, _visited: Optional[Set[str]] = None) -> Dict[str, List[str]]:
     """
     Parse a terragrunt.hcl file and extract file patterns for when_modified tracking.
 
@@ -451,6 +451,13 @@ def parse_terragrunt_dependencies(file_path: str, base_dir: str, root_path: Opti
         "dependencies": [],
         "extra_deps": []
     }
+
+    # Includes are followed, so stop if a parent chain ever comes back around.
+    _visited = set() if _visited is None else _visited
+    if file_path in _visited:
+        return result
+    _visited.add(file_path)
+    inherited_sources = []
 
     if root_path is None:
         file_parent = Path(file_path).resolve().parent
@@ -483,15 +490,30 @@ def parse_terragrunt_dependencies(file_path: str, base_dir: str, root_path: Opti
                     result['includes'].append(resolved_path)
                     log(f"  Found include: {path_value} -> {resolved_path}", "DEBUG")
 
+                    parent = parse_terragrunt_dependencies(
+                        os.path.join(root_path, resolved_path),
+                        base_dir,
+                        root_path,
+                        _visited
+                    )
+                    result['includes'].extend(parent['includes'])
+                    inherited_sources.extend(parent['terraform_sources'])
+
         # Extract terraform.source for local modules
         if 'terraform' in parsed:
             for terraform_block in iter_hcl_blocks(parsed['terraform']):
                 source = hcl_string(terraform_block.get('source'))
-                if source and is_local_source(source):
-                    resolved_path = resolve_relative_path(base_dir, source)
+                if source:
+                    resolved_path = resolve_source_path(base_dir, source)
                     if resolved_path:
                         result['terraform_sources'].append(resolved_path)
                         log(f"  Found local terraform source: {source} -> {resolved_path}", "DEBUG")
+
+        # A source on the unit overrides one from a parent, the way Terragrunt merges
+        # the terraform block, so an inherited source is used only when the unit sets
+        # none of its own.
+        if not result['terraform_sources']:
+            result['terraform_sources'].extend(inherited_sources)
 
         # Extract dependency "name" { config_path = "../dir" } blocks.
         if 'dependency' in parsed:
@@ -587,6 +609,35 @@ def is_local_source(source: str) -> bool:
     # Per Terraform spec: local paths start with ./ or ../ (relative) or / (absolute)
     # Everything else is remote or unresolvable - skip it
     return source.startswith('./') or source.startswith('../') or source.startswith('/')
+
+
+def resolve_source_path(base_dir: str, source: str) -> Optional[str]:
+    """
+    Resolve a terraform.source to a repository-relative path when it is local.
+
+    is_local_source covers ./ and ../ . A source written as ${get_repo_root()}//path
+    names a path in the repository just as plainly, and is the usual way to write one in
+    a shared parent because it does not depend on how deep the unit sits.
+    resolve_include_path already resolves find_in_parent_folders for include paths on the
+    same reasoning, so it is resolved here too. Remote sources return None.
+
+    Args:
+        base_dir: Directory the source is resolved against
+        source: The terraform.source string
+
+    Returns:
+        Path relative to the repository root, or None if the source is not local
+    """
+    repo_root = '${get_repo_root()}'
+
+    if source.startswith(repo_root):
+        path = source[len(repo_root):].strip('/')
+        return resolve_relative_path('', path) if path else None
+
+    if is_local_source(source):
+        return resolve_relative_path(base_dir, source)
+
+    return None
 
 
 def resolve_relative_path(base_dir: str, relative_path: str) -> Optional[str]:


### PR DESCRIPTION
`parse_terragrunt_dependencies` reads `terraform.source` from a unit's own `terragrunt.hcl`. Setting one source in an included parent and sharing it across an environment is a normal way to lay a Terragrunt repository out, and in that shape no unit tracks the module it deploys: the include is recorded in `includes`, but the file it points at is never read, so `terraform_sources` comes back empty and editing the module matches nothing.

The failure is quiet. `depends_on` is still correct, because that comes from `terragrunt list` rather than from parsing, so the configuration looks right while a whole class of `file_patterns` is missing.

This is handled automatically by terragrunt-atlantis-config, which the config builder is modelled on. It reads the merged configuration from Terragrunt's own parser, so a source set in a parent is already resolved by the time it looks:

```go
if parsedConfig.Terraform != nil && parsedConfig.Terraform.Source != nil {
    parsedSource, err := getter.Detect(*source, filepath.Dir(path), getter.Detectors)
```

Note `filepath.Dir(path)` — the unit's directory, not the parent's. `extra_atlantis_dependencies` is not the answer here; that is documented for what detection cannot see, such as files read through `read_terragrunt_config`.

## The two commits

**`FIX resolve terraform.source when it is set by an included parent`** parses a resolved include as well. Its sources belong to the unit that included it, and so do any includes of its own, otherwise a parent that includes a further file leaves that file unwatched. A source on the unit takes precedence over an inherited one, matching how Terragrunt merges the `terraform` block. `base_dir` stays the unit's throughout, because Terragrunt evaluates an included config in the unit's context. Recursion is bounded by a visited set.

`resolve_source_path` also accepts `${get_repo_root()}//path`, which is the usual way to write a source in a shared parent precisely because it does not depend on how deep the unit sits. `is_local_source` treats every interpolation as remote, but this one names a path in the repository as plainly as `../` does, and `resolve_include_path` already resolves `find_in_parent_folders` for include paths on the same reasoning. Remote sources still resolve to `None`.

**`ADD follow module-to-module sources when building file patterns`** extends the same patterns one hop: a module wrapping another is changed by an edit to either. Parsed with `hcl2` rather than matched textually, so a `source` in a comment is not mistaken for one and only `module` blocks are considered — not, for instance, the entries in `required_providers`. What a directory refers to is remembered, the way `getDependencies` is cached in terragrunt-atlantis-config.

Separable: the first makes a unit track the module it deploys, the second extends it.

## Validation

Semantics checked against Terragrunt rather than assumed:

| question | how | answer |
|---|---|---|
| what is a parent's relative source relative to? | `terragrunt init` on a parent at `live/module.hcl` with `source = "../../mod"` | downloads from `mod`, i.e. relative to the unit at `live/prod` |
| which source wins when both are set? | `terragrunt info` | `working_dir` is the unit's own source |

Behaviour, each as its own fixture:

| case | result |
|---|---|
| source in an included parent | unit gains the module's pattern |
| parent that includes a further parent | the grandparent file is watched too |
| pair of parents including each other | terminates |
| `source` in a comment in a `.tf` | not mistaken for a source |
| `${get_repo_root()}` with no path after it | resolves to nothing, not to the repository root |
| unit overrides the parent's source | only the unit's is watched |
| module wrapping another module | both are watched |
| `dependency` declared in a parent | unaffected, still resolved via `terragrunt list` |

On a private monorepo of 28 Terragrunt units across three AWS accounts, before and after:

| | before | after |
|---|---|---|
| units tracking the module they deploy | 2 / 28 | 28 / 28 |
| distinct modules reachable from a unit | 2 / 25 | 25 / 25 |
| `depends_on` edges | 4 | 4 (unchanged) |
| patterns pointing outside the repository | 0 | 0 |

Before, a pull request editing a shared module matched a directory with no `terragrunt.hcl` and failed with `You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file`, while the units that deploy that module were never selected.

Run in the action container, not only locally: no `hcl2` parse failures across the repository's `.tf` files.

Caching, after warming the parser so its one-time start-up does not flatter the result: on a chain of six modules, about 2.3 ms per unit without it and nothing measurable with it. Tens of milliseconds across 28 units, which is why it would not be worth writing at that size; the config builder is aimed at monorepos with hundreds of modules.

## Notes

There is no existing issue for this, so the title carries no issue number.

There are no tests for the config builder in this repository, so nothing catches a regression here automatically. The fixtures above are ready to become one if you would like that added.

Happy to reshape this — folding the resolution into `is_local_source` and `parse_terragrunt_dependencies` differently, or dropping the second commit — if either fits the codebase better.
