### PR TITLE
Bump base image to action-base:1786971497 for ansible-core 2.15.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1781682162
+ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1786971497
 FROM ${BASE_IMAGE}
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
#631 and #632 changed `Dockerfile.base`, but that file is only the recipe — `Dockerfile` line 1 pins an already-built image, and it still pointed at `action-base:1781682162`, the tag built in June with ansible-core 2.20.3. So the 2.15.7 pin never reached a published layer and runs kept getting 2.20.3.

`ghcr.io/terrateamio/action-base:1786971497` is a fresh build of `Dockerfile.base` from this branch. This points `Dockerfile` at it.

## Verification

Pulled `ghcr.io/terrateamio/action-base:1786971497` (digest `sha256:40abb4ef…`) and inspected it:

- `ansible-playbook` and `ansible-galaxy` both report core 2.15.7
- `/opt/ansible` holds ansible-core 2.15.7, ansible 8.7.0, pywinrm 0.5.0
- `ENV ANSIBLE_VERSION` is 2.15.7, matching the `proxy/bin/ansible-playbook` shim default
- `proxy/bin/oci` from eff6f1a is present in the image

No existing tag was modified and `:latest` is untouched, so users pinned to older action SHAs are unaffected.
