### PR TITLE
#640 FIX mark md5 fingerprint uses as usedforsecurity=False

### DIFF
--- a/terrat_runner/runtime/github_actions/workflow_step_drift_create_issue.py
+++ b/terrat_runner/runtime/github_actions/workflow_step_drift_create_issue.py
@@ -158,7 +158,7 @@ def dirspace_issue_title(dirspace):
 
 def create_aggregated_issue(state, dirspaces_with_changes):
     all_dirspace_plan_output = format_dirspaces(dirspaces_with_changes)
-    report_id = hashlib.md5(all_dirspace_plan_output.encode('utf-8')).hexdigest()
+    report_id = hashlib.md5(all_dirspace_plan_output.encode('utf-8'), usedforsecurity=False).hexdigest()
     existing_issue = find_matching_issue(state.env, report_id)
     if existing_issue:
         logging.info('DRIFT_CREATE_ISSUE : ISSUE_EXISTS : %s', existing_issue['id'])
@@ -171,7 +171,7 @@ def create_per_dirspace_issues(state, dirspaces_with_changes):
     for dirspace in dirspaces_with_changes:
         plan_output = format_dirspace_output(
             dirspace['dir'], dirspace['workspace'], dirspace['plan'], dirspace['success'])
-        report_id = hashlib.md5(plan_output.encode('utf-8')).hexdigest()
+        report_id = hashlib.md5(plan_output.encode('utf-8'), usedforsecurity=False).hexdigest()
         title = dirspace_issue_title(dirspace)
         existing_issue = find_matching_issue(state.env, report_id)
         if existing_issue:

--- a/terrat_runner/runtime/gitlab_ci/workflow_step_drift_create_issue.py
+++ b/terrat_runner/runtime/gitlab_ci/workflow_step_drift_create_issue.py
@@ -166,7 +166,7 @@ def dirspace_issue_title(dirspace):
 
 def create_aggregated_issue(state, dirspaces_with_changes):
     all_dirspace_plan_output = format_dirspaces(dirspaces_with_changes)
-    report_id = hashlib.md5(all_dirspace_plan_output.encode('utf-8')).hexdigest()
+    report_id = hashlib.md5(all_dirspace_plan_output.encode('utf-8'), usedforsecurity=False).hexdigest()
     existing_issue = find_matching_issue(state.env, report_id)
     if existing_issue:
         logging.info('DRIFT_CREATE_ISSUE : ISSUE_EXISTS : %s', existing_issue['id'])
@@ -179,7 +179,7 @@ def create_per_dirspace_issues(state, dirspaces_with_changes):
     for dirspace in dirspaces_with_changes:
         plan_output = format_dirspace_output(
             dirspace['dir'], dirspace['workspace'], dirspace['plan'], dirspace['success'])
-        report_id = hashlib.md5(plan_output.encode('utf-8')).hexdigest()
+        report_id = hashlib.md5(plan_output.encode('utf-8'), usedforsecurity=False).hexdigest()
         title = dirspace_issue_title(dirspace)
         existing_issue = find_matching_issue(state.env, report_id)
         if existing_issue:

--- a/terrat_runner/workflow_step_apply.py
+++ b/terrat_runner/workflow_step_apply.py
@@ -27,7 +27,7 @@ def _load_plan(state, work_token, api_base_url, dir_path, workspace, plan_path):
             logging.debug('APPLY : LOAD_PLAN : dir_path=%s : workspace=%s : md5=%s',
                           dir_path,
                           workspace,
-                          hashlib.md5(plan_data_raw).hexdigest())
+                          hashlib.md5(plan_data_raw, usedforsecurity=False).hexdigest())
 
             with open(plan_path, 'wb') as f:
                 f.write(plan_data_raw)
@@ -51,7 +51,7 @@ def _load_plan(state, work_token, api_base_url, dir_path, workspace, plan_path):
         logging.debug('APPLY : LOAD_PLAN : dir_path=%s : workspace=%s : md5=%s',
                       dir_path,
                       workspace,
-                      hashlib.md5(plan_data_raw).hexdigest())
+                      hashlib.md5(plan_data_raw, usedforsecurity=False).hexdigest())
 
         with open(plan_path, 'wb') as f:
             f.write(plan_data_raw)

--- a/terrat_runner/workflow_step_plan.py
+++ b/terrat_runner/workflow_step_plan.py
@@ -45,7 +45,7 @@ def _store_plan_terrateam(work_token, api_base_url, dir_path, workspace, plan_pa
         logging.debug('PLAN : STORE_PLAN : dir_path=%s : workspace=%s : md5=%s',
                       dir_path,
                       workspace,
-                      hashlib.md5(plan_data_raw).hexdigest())
+                      hashlib.md5(plan_data_raw, usedforsecurity=False).hexdigest())
 
         return _store_plan_data(plan_data,
                                 work_token,


### PR DESCRIPTION
Closes #640.

hashlib.md5 is only used for plan-file debug fingerprints and drift-report ids (non-security). Passing usedforsecurity=False declares that intent and clears the weak-hash static-analysis finding. No behavioural change; Python >=3.9 (both action-base variants).