### PR TITLE
#649 ADD container image scanning and Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: "/" # Location of workflow files
     schedule:
       interval: "weekly" # How often to check for updates
+
+  # Keep the Dockerfile base images current. Freshness to complement detection:
+  # container-scan.yaml finds CVEs in the published images, Dependabot moves the
+  # FROM line forward so a fix can land. Note Dockerfile.base.bullseye still
+  # targets debian:bullseye (oldoldstable) — expect that one to need a decision
+  # rather than a bump.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -78,3 +78,52 @@ jobs:
         with:
           sarif_file: trivy.sarif
           category: trivy-${{ matrix.image }}
+
+  # A scan nobody reads is not a control. Scheduled-workflow failure emails go only
+  # to whoever last touched the cron line, which is not a dependable alerting path.
+  # So a failure opens (or updates) a tracking issue: no secrets needed, identical
+  # in every repo, and the issue is itself the record that a finding was detected
+  # and acted on. Alerting is wired off these issues separately.
+  notify-failure:
+    name: Open tracking issue
+    needs: scan
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE='Container scan: fixable HIGH/CRITICAL vulnerabilities in shipped images'
+          # Best-effort label so a missing label can never fail the alert itself.
+          gh label create container-scan --repo "$REPO" --color d73a4a \
+            --description 'Automated container image vulnerability scan findings' >/dev/null 2>&1 || true
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "Still failing on the scheduled run of $(date -u '+%Y-%m-%d %H:%M UTC'). $RUN_URL"
+            echo "Updated existing issue #$EXISTING"
+            exit 0
+          fi
+          # printf, not a heredoc: heredoc lines inside a YAML block scalar must stay
+          # indented, and that indentation would turn the body into a code block.
+          printf '%s\n' \
+            'The weekly container image scan found HIGH or CRITICAL vulnerabilities **with a fix available** in at least one image we ship.' \
+            '' \
+            "Run: $RUN_URL" \
+            '' \
+            'Per the Vulnerability Management Policy, remediation timelines run from confirmation. Triage the findings in the run output, then either bump the affected package / base image or record an explicit risk acceptance with justification.' \
+            '' \
+            'This issue is reused by later runs rather than reopened weekly, so it stays one thread until the scan is green. Close it once the scan passes.' \
+            > /tmp/scan-issue-body.md
+          gh issue create --repo "$REPO" --title "$TITLE" --label container-scan \
+            --body-file /tmp/scan-issue-body.md >/dev/null
+          echo "Opened a new tracking issue"

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -79,51 +79,9 @@ jobs:
           sarif_file: trivy.sarif
           category: trivy-${{ matrix.image }}
 
-  # A scan nobody reads is not a control. Scheduled-workflow failure emails go only
-  # to whoever last touched the cron line, which is not a dependable alerting path.
-  # So a failure opens (or updates) a tracking issue: no secrets needed, identical
-  # in every repo, and the issue is itself the record that a finding was detected
-  # and acted on. Alerting is wired off these issues separately.
-  notify-failure:
-    name: Open tracking issue
-    needs: scan
-    if: failure() && github.event_name == 'schedule'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Open or update the tracking issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          TITLE='Container scan: fixable HIGH/CRITICAL vulnerabilities in shipped images'
-          # Best-effort label so a missing label can never fail the alert itself.
-          gh label create container-scan --repo "$REPO" --color d73a4a \
-            --description 'Automated container image vulnerability scan findings' >/dev/null 2>&1 || true
-          EXISTING=$(gh issue list --repo "$REPO" --state open \
-            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$REPO" \
-              --body "Still failing on the scheduled run of $(date -u '+%Y-%m-%d %H:%M UTC'). $RUN_URL"
-            echo "Updated existing issue #$EXISTING"
-            exit 0
-          fi
-          # printf, not a heredoc: heredoc lines inside a YAML block scalar must stay
-          # indented, and that indentation would turn the body into a code block.
-          printf '%s\n' \
-            'The weekly container image scan found HIGH or CRITICAL vulnerabilities **with a fix available** in at least one image we ship.' \
-            '' \
-            "Run: $RUN_URL" \
-            '' \
-            'Per the Vulnerability Management Policy, remediation timelines run from confirmation. Triage the findings in the run output, then either bump the affected package / base image or record an explicit risk acceptance with justification.' \
-            '' \
-            'This issue is reused by later runs rather than reopened weekly, so it stays one thread until the scan is green. Close it once the scan passes.' \
-            > /tmp/scan-issue-body.md
-          gh issue create --repo "$REPO" --title "$TITLE" --label container-scan \
-            --body-file /tmp/scan-issue-body.md >/dev/null
-          echo "Opened a new tracking issue"
+# NOTE: deliberately NO issue-creating notify job here, unlike stategraph/mono.
+# This repo is public: an issue titled "fixable HIGH/CRITICAL vulnerabilities in
+# shipped images" -- and the public workflow-run logs it links to -- would disclose
+# unfixed vulnerabilities in released customer images. Findings go to code scanning
+# via the SARIF upload above instead, which is visible only to users with write,
+# maintain or admin access (and org owners), not to the public.

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -1,0 +1,80 @@
+# Scan the published action images for known OS/library vulnerabilities.
+#
+# This image is what customers execute in their own CI, so a vulnerable layer here
+# runs on their infrastructure, not just ours.
+#
+# Scans PUBLISHED tags on a schedule rather than at build time: the point of
+# container scanning is catching advisories disclosed *after* an image was built,
+# which a build-time-only scan never sees.
+#
+# Results are also uploaded to GitHub code scanning (Security tab) — free on this
+# public repo. Note stategraph/mono cannot do this: it is private, and code-scanning
+# upload there requires paid GitHub Code Security.
+name: container scan
+
+on:
+  schedule:
+    # Mondays 06:15 UTC — offset from the mono scan so the two don't collide.
+    - cron: '15 6 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'Dockerfile*'
+      - '.github/workflows/container-scan.yaml'
+
+jobs:
+  scan:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          # The action image customers run. Its base layers (action-base, and the
+          # debian image under that) are inside this image, so Trivy covers them
+          # transitively — no separate base scan needed. There is also no
+          # `action-base:latest` tag to scan: that package is tagged by timestamp
+          # only, and Dockerfile pins an explicit one.
+          - ghcr.io/terrateamio/action:v1
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ignore-unfixed: a vulnerability with no upstream fix is not actionable by
+      # us, and failing on it would keep this check permanently red — which trains
+      # everyone to ignore it. Unfixed findings still reach the Security tab below.
+      - name: Trivy scan (fail on fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: Trivy scan (full SARIF, all severities)
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          scanners: vuln
+          format: sarif
+          output: trivy.sarif
+          exit-code: '0'
+
+      - name: Upload to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-${{ matrix.image }}


### PR DESCRIPTION
Closes #649.

Nothing scanned the action image for OS/library vulnerabilities. **This image is what customers execute in their own CI**, so a vulnerable layer here runs on their infrastructure, not just ours — which makes it arguably the highest-consequence image we publish.

### `container-scan.yaml`
Weekly Trivy scan (plus `workflow_dispatch`, and on PRs touching `Dockerfile*`) of the published `ghcr.io/terrateamio/action:v1`, with **SARIF upload to the Security tab** — code scanning is free on this public repo. (`stategraph/mono` can't do that: it's private and would need paid GitHub Code Security, so its evidence is a job artifact instead.)

**Why the published tag, not build time:** the value of container scanning is catching advisories disclosed *after* an image was built. A build-time-only scan never notices that today's CVE affects the image already in customers' pipelines.

**Why `ignore-unfixed: true` on the failing check:** a vulnerability with no upstream fix isn't actionable by us, and failing on it keeps the check permanently red — which trains everyone to ignore it. Fails on HIGH/CRITICAL *with a fix available*; the SARIF upload still carries everything, including unfixed.

**Only `action:v1` is scanned, deliberately.** Trivy scans all layers, so `action-base` and the debian image beneath it are covered transitively. I'd initially added `action-base:latest` as a second target and checked before shipping — **that tag doesn't exist**; the package is tagged by timestamp only (`1786971497`), and `Dockerfile` pins an explicit one. So it would have failed to pull.

### `dependabot.yml` — `docker` ecosystem
Weekly base-image bumps. Trivy finds the CVE, Dependabot moves the `FROM` line so the fix can land.

⚠️ Worth a look on its own: **`Dockerfile.base.bullseye` still targets `debian:bullseye-20220622-slim`** — Debian oldoldstable, pinned to a mid-2022 snapshot. That probably needs a decision about whether the bullseye variant is still supported, not a Dependabot bump.

**Expect the first run to find things** — this image has never been scanned. That's the control working.