### PR TITLE
#651 ADD Dependabot docker updates for base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: "/" # Location of workflow files
     schedule:
       interval: "weekly" # How often to check for updates
+
+  # Keep the Dockerfile base images current. This must live here, not in
+  # stategraph/mono: mono scans the published action image, but the Dockerfiles it
+  # is built from are owned by this repo, so the FROM bumps have to happen here.
+  # Note Dockerfile.base.bullseye still targets debian:bullseye (oldoldstable) --
+  # expect that one to need a decision rather than a bump.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #651.

Enables Dependabot's `docker` ecosystem weekly for this repo's Dockerfiles.

Container image scanning for `ghcr.io/terrateamio/action:v1` was consolidated into **stategraph/mono#1908** (private), so findings don't land in public workflow logs or issues. Base-image bumps can't be consolidated the same way — the Dockerfiles are owned by this repo, so the `FROM` updates have to happen here. Scanning in mono finds the CVE; Dependabot here moves the `FROM` line so the fix can land.

⚠️ Worth a separate decision: `Dockerfile.base.bullseye` still targets `debian:bullseye-20220622-slim` — oldoldstable, pinned to a mid-2022 snapshot. That likely needs a call on whether the bullseye variant is still supported, rather than a Dependabot bump.