### PR TITLE
stategraph/mono#2027 ADD terragrunt-config-builder --no-create-and-select-workspace

### DIFF
--- a/bin/terragrunt-config-builder
+++ b/bin/terragrunt-config-builder
@@ -896,7 +896,8 @@ def generate_terrateam_config(
     all_dependencies: Dict[str, Dict],
     dependency_graph: Dict[str, List[str]],
     root_path: str,
-    scan_tf_files: bool = False
+    scan_tf_files: bool = False,
+    create_and_select_workspace: bool = True
 ) -> Dict:
     """
     Generate Terrateam configuration with dirs entries for each terragrunt directory.
@@ -910,6 +911,11 @@ def generate_terrateam_config(
             modules they reach) for module sources and file references
             (templatefile, file, ...). When False, only terraform.source modules
             declared in terragrunt.hcl are followed.
+        create_and_select_workspace: When False, every generated dir entry sets
+            create_and_select_workspace to false, so Terrateam does not run
+            `workspace new`/`workspace select` before the unit. Terragrunt
+            normally manages workspaces itself. When True (the default) the key
+            is left out and Terrateam keeps its own default.
 
     Returns:
         Modified configuration with generated dirs entries
@@ -980,6 +986,11 @@ def generate_terrateam_config(
             }
         }
 
+        # Only emit the key when the user opted out of workspace handling. Left
+        # out, the dir keeps whatever default Terrateam applies.
+        if not create_and_select_workspace:
+            dir_config["create_and_select_workspace"] = False
+
         # Add depends_on if there are dependencies
         if direct_deps:
             # Format as Terrateam tag query: "dir:path1 or dir:path2"
@@ -1008,6 +1019,19 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             "module sources and file references such as templatefile()/file(), and "
             "track those files. Without this flag only terraform.source modules "
             "declared in terragrunt.hcl are followed."
+        )
+    )
+    parser.add_argument(
+        '--no-create-and-select-workspace',
+        dest='create_and_select_workspace',
+        action='store_false',
+        default=True,
+        help=(
+            "Set create_and_select_workspace to false on every generated dir "
+            "entry, so Terrateam does not create and select a workspace before "
+            "running the unit. Use this when Terragrunt manages workspaces "
+            "itself. Without this flag the key is left out and the Terrateam "
+            "default applies."
         )
     )
     return parser.parse_args(argv)
@@ -1064,7 +1088,8 @@ def main():
             all_dependencies,
             dependency_graph,
             repo_root,
-            scan_tf_files=cli_args.scan_tf_files
+            scan_tf_files=cli_args.scan_tf_files,
+            create_and_select_workspace=cli_args.create_and_select_workspace
         )
 
         # Output final config to stdout

--- a/terrat_runner/test_terragrunt_config_builder.py
+++ b/terrat_runner/test_terragrunt_config_builder.py
@@ -1,0 +1,99 @@
+import io
+import json
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from unittest import mock
+
+
+def _load_builder():
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'bin',
+        'terragrunt-config-builder')
+    loader = SourceFileLoader('terragrunt_config_builder', path)
+    spec = spec_from_loader(loader.name, loader)
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+builder = _load_builder()
+
+
+def generate(dirs, **kwargs):
+    return builder.generate_terrateam_config(
+        {},
+        dirs,
+        {d: {} for d in dirs},
+        {},
+        '/repo',
+        **kwargs)
+
+
+class ParseArgsTest(unittest.TestCase):
+    def test_default_is_opt_out(self):
+        # No flag: the builder leaves workspace handling alone.
+        self.assertTrue(builder.parse_args([]).create_and_select_workspace)
+
+    def test_flag_disables_workspace(self):
+        args = builder.parse_args(['--no-create-and-select-workspace'])
+        self.assertFalse(args.create_and_select_workspace)
+
+    def test_flag_composes_with_scan_tf_files(self):
+        args = builder.parse_args(['--scan-tf-files', '--no-create-and-select-workspace'])
+        self.assertTrue(args.scan_tf_files)
+        self.assertFalse(args.create_and_select_workspace)
+
+
+class GenerateConfigTest(unittest.TestCase):
+    def test_key_absent_by_default(self):
+        config = generate(['prod/vpc', 'prod/app'])
+        for dir_config in config['dirs'].values():
+            self.assertNotIn('create_and_select_workspace', dir_config)
+
+    def test_key_absent_when_explicitly_enabled(self):
+        config = generate(['prod/vpc'], create_and_select_workspace=True)
+        self.assertNotIn('create_and_select_workspace', config['dirs']['prod/vpc'])
+
+    def test_key_false_on_every_dir_when_disabled(self):
+        config = generate(['prod/vpc', 'prod/app', ''], create_and_select_workspace=False)
+        self.assertEqual(sorted(config['dirs']), ['.', 'prod/app', 'prod/vpc'])
+        for dir_config in config['dirs'].values():
+            self.assertIs(dir_config['create_and_select_workspace'], False)
+
+    def test_rest_of_the_dir_entry_is_unchanged(self):
+        enabled = generate(['prod/vpc'])['dirs']['prod/vpc']
+        disabled = generate(['prod/vpc'], create_and_select_workspace=False)['dirs']['prod/vpc']
+        self.assertEqual(disabled.pop('create_and_select_workspace'), False)
+        self.assertEqual(disabled, enabled)
+
+
+class MainTest(unittest.TestCase):
+    def run_main(self, argv):
+        stdout = io.StringIO()
+
+        with mock.patch.object(builder.sys, 'argv', ['terragrunt-config-builder'] + argv), \
+             mock.patch.object(builder.sys, 'stdin', io.StringIO(json.dumps({'dirs': {}}))), \
+             mock.patch.object(builder.sys, 'stdout', stdout), \
+             mock.patch.dict(builder.os.environ, {'TERRATEAM_ROOT': '/repo'}), \
+             mock.patch.object(builder, 'configure_terragrunt_env'), \
+             mock.patch.object(builder, 'discover_terragrunt_files', return_value=['prod/vpc']), \
+             mock.patch.object(builder, 'get_terragrunt_dependencies', return_value={}), \
+             mock.patch.object(builder, 'parse_terragrunt_dependencies', return_value={}):
+            builder.main()
+
+        return json.loads(stdout.getvalue())
+
+    def test_flag_reaches_stdout(self):
+        config = self.run_main(['--no-create-and-select-workspace'])
+        self.assertIs(config['dirs']['prod/vpc']['create_and_select_workspace'], False)
+
+    def test_no_flag_leaves_stdout_alone(self):
+        config = self.run_main([])
+        self.assertNotIn('create_and_select_workspace', config['dirs']['prod/vpc'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes stategraph/mono#2027

## What

Adds an opt-in `--no-create-and-select-workspace` flag to `bin/terragrunt-config-builder`. With the flag, every generated `dirs` entry gets `create_and_select_workspace: false`, so Terrateam does not run `workspace new` / `workspace select` before the unit. Terragrunt manages workspaces itself.

```yaml
config_builder:
  enabled: true
  script: terragrunt-config-builder --no-create-and-select-workspace
```

The `config_builder.script` field runs as a bash script, so arguments work. The flag also composes with the existing `--scan-tf-files`.

## Why not the top-level key

`terrat_runner/repo_config.py:get_create_and_select_workspace` falls back to the top-level `create_and_select_workspace` when the dir entry omits the key, but the top-level value does not reach the generated dirs in practice, so users had no way to opt out.

## Behavior

- Without the flag the generated `dirs` entries are byte-for-byte what they were before. The key is not emitted, so the Terrateam default still applies.
- With the flag each generated `dirs` entry gets `create_and_select_workspace: false`. Nothing else in the entry changes.

## Tests

New `terrat_runner/test_terragrunt_config_builder.py`, 9 tests over `parse_args`, `generate_terrateam_config`, and `main` (argv through to the JSON on stdout).

```
$ cd terrat_runner && python3 -m unittest discover -p 'test_*.py'
Ran 31 tests in 0.008s
OK
```

Mutation-checked: disabling the new emit fails 3 of the new tests; restoring it returns the suite to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
