### PR TITLE
stategraph/mono#2044 ADD terragrunt-config-builder --exclude-file-pattern

### DIFF
--- a/bin/terragrunt-config-builder
+++ b/bin/terragrunt-config-builder
@@ -18,7 +18,7 @@ import json
 import os
 import sys
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Set
 import re
 
@@ -575,6 +575,138 @@ def parse_terragrunt_dependencies(file_path: str, base_dir: str, root_path: Opti
     return result
 
 
+# Path_glob, which Terrateam parses file_patterns with, also understands '{a,b}'
+# alternation, '[a-z]' classes, and a leading '!' for negation. None of those are
+# translated here, so a glob using them would silently match nothing.
+UNSUPPORTED_GLOB_SYNTAX = ('{', '}', '[', ']')
+
+# Terrateam escapes these before handing a file_pattern to Path_glob, so their
+# braces are literal rather than alternation. glob_to_regex escapes them too.
+LITERAL_GLOB_TOKENS = ('${DIR}', '${WORKSPACE}')
+
+
+def glob_to_regex(glob: str) -> str:
+    """
+    Translate a glob into a regex, using a subset of the Terrateam file_patterns
+    dialect: '*', '**' and '?'.
+
+    '**' spans path separators, '*' and '?' stop at one. pathlib.PurePath.match
+    cannot be used here: before Python 3.13 it reads '**' as a single component,
+    so 'provisioning/modules/**' would quietly match nothing.
+    """
+    out = []
+    i = 0
+
+    while i < len(glob):
+        char = glob[i]
+
+        if glob.startswith('**', i):
+            i += 2
+            if i < len(glob) and glob[i] == '/':
+                # '**/x' has to match a bare 'x' as well as 'a/b/x'.
+                i += 1
+                out.append('(?:.*/)?')
+            else:
+                out.append('.*')
+        elif char == '*':
+            i += 1
+            out.append('[^/]*')
+        elif char == '?':
+            i += 1
+            out.append('[^/]')
+        else:
+            i += 1
+            out.append(re.escape(char))
+
+    return '^' + ''.join(out) + r'\Z'
+
+
+def validate_exclude_globs(exclude_globs: List[str]) -> List[str]:
+    """
+    Drop unusable --exclude-file-pattern globs, reporting each one once.
+
+    matches_exclude runs per file_pattern per dir, so warning in there turns one
+    bad glob into thousands of identical lines in a real monorepo and buries the
+    warnings that matter. Report here instead, once per glob.
+
+    A glob using syntax glob_to_regex does not translate is kept, because it is
+    still a valid literal match, but it is called out: silently matching nothing
+    leaves the user with the fan-out they were trying to remove. '${DIR}' and
+    '${WORKSPACE}' are exempt, since Terrateam treats their braces as literal too.
+    """
+    kept = []
+
+    for glob in exclude_globs:
+        if not glob:
+            log("Ignoring empty --exclude-file-pattern", "WARN")
+            continue
+
+        bare = glob
+
+        for token in LITERAL_GLOB_TOKENS:
+            bare = bare.replace(token, '')
+
+        if glob.startswith('!') or any(c in bare for c in UNSUPPORTED_GLOB_SYNTAX):
+            log(
+                f"--exclude-file-pattern {glob!r} uses glob syntax this flag does not "
+                "translate; only '*', '**' and '?' are supported, so it will likely "
+                "match nothing",
+                "WARN"
+            )
+
+        kept.append(glob)
+
+    return kept
+
+
+def matches_exclude(file_pattern: str, exclude_globs: List[str]) -> bool:
+    """
+    Report whether a generated file_pattern should be dropped.
+
+    A glob holding no '/' is matched against the file name alone, so
+    'provider*.hcl' drops that file wherever it sits. Any other glob is matched
+    against the whole repo-relative path, so 'provisioning/modules/**' drops only
+    what lives under that directory.
+
+    The globs are expected to have been through validate_exclude_globs, which
+    reports the unusable ones once rather than once per file_pattern per dir.
+    """
+    name = PurePosixPath(file_pattern).name
+
+    for glob in exclude_globs:
+        target = file_pattern if '/' in glob else name
+
+        if re.match(glob_to_regex(glob), target):
+            return True
+
+    return False
+
+
+def apply_exclusions(file_patterns: List[str], exclude_globs: List[str], dir_path: str) -> List[str]:
+    """
+    Drop generated file_patterns matching any exclude glob.
+
+    A unit that no longer watches its own terragrunt.hcl can never autoplan, and
+    that failure is silent at run time, so say so loudly here instead.
+    """
+    if not exclude_globs:
+        return file_patterns
+
+    kept = [p for p in file_patterns if not matches_exclude(p, exclude_globs)]
+
+    if '${DIR}/terragrunt.hcl' in file_patterns and '${DIR}/terragrunt.hcl' not in kept:
+        log(
+            f"Exclusions removed ${{DIR}}/terragrunt.hcl from {dir_path or '.'}; "
+            "this unit will no longer autoplan when its own config changes",
+            "WARN"
+        )
+
+    if not kept:
+        log(f"Exclusions removed every file_pattern from {dir_path or '.'}", "WARN")
+
+    return kept
+
+
 def dedupe(values: List[str]) -> List[str]:
     """
     Preserve order while removing duplicates.
@@ -897,7 +1029,8 @@ def generate_terrateam_config(
     dependency_graph: Dict[str, List[str]],
     root_path: str,
     scan_tf_files: bool = False,
-    create_and_select_workspace: bool = True
+    create_and_select_workspace: bool = True,
+    exclude_file_patterns: Optional[List[str]] = None
 ) -> Dict:
     """
     Generate Terrateam configuration with dirs entries for each terragrunt directory.
@@ -916,11 +1049,16 @@ def generate_terrateam_config(
             `workspace new`/`workspace select` before the unit. Terragrunt
             normally manages workspaces itself. When True (the default) the key
             is left out and Terrateam keeps its own default.
+        exclude_file_patterns: Globs of generated file_patterns to drop. A shared
+            include such as a parent terragrunt.hcl or a provider.hcl lands in
+            every unit that includes it, so editing one line fans out across the
+            repo. Empty by default, which keeps every generated pattern.
 
     Returns:
         Modified configuration with generated dirs entries
     """
     output_config = input_config.copy()
+    exclude_file_patterns = exclude_file_patterns or []
 
     # Ensure dirs key exists
     if "dirs" not in output_config:
@@ -976,7 +1114,7 @@ def generate_terrateam_config(
         for dep_dir in direct_deps:
             file_patterns.append(f"{dep_dir}/terragrunt.hcl")
 
-        file_patterns = dedupe(file_patterns)
+        file_patterns = apply_exclusions(dedupe(file_patterns), exclude_file_patterns, dir_path)
 
         # Build dir configuration
         dir_config = {
@@ -1034,6 +1172,25 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             "default applies."
         )
     )
+    parser.add_argument(
+        '--exclude-file-pattern',
+        dest='exclude_file_patterns',
+        action='append',
+        default=[],
+        metavar='GLOB',
+        help=(
+            "Drop any generated file_pattern matching GLOB, and repeat the flag "
+            "for more than one. Use it when a shared include such as a parent "
+            "terragrunt.hcl or a provider.hcl is pulled into every unit, so that "
+            "editing one line no longer plans the whole repo. GLOB uses a subset "
+            "of the file_patterns dialect, '*', '**' and '?', where '**' spans "
+            "directories: a glob with no '/' matches the file name anywhere, such "
+            "as 'provider*.hcl', and any other glob matches the repo-relative "
+            "path, such as 'provisioning/modules/**'. Brace alternation, character "
+            "classes and '!' negation are not translated. Without this flag "
+            "nothing is dropped."
+        )
+    )
     return parser.parse_args(argv)
 
 
@@ -1053,6 +1210,9 @@ def main():
             sys.exit(1)
 
         log(f"Repository root: {repo_root}")
+
+        # Report unusable globs once, before they reach the per-dir loop.
+        exclude_file_patterns = validate_exclude_globs(cli_args.exclude_file_patterns)
 
         # Read input config from stdin
         log("Reading configuration from stdin...")
@@ -1089,7 +1249,8 @@ def main():
             dependency_graph,
             repo_root,
             scan_tf_files=cli_args.scan_tf_files,
-            create_and_select_workspace=cli_args.create_and_select_workspace
+            create_and_select_workspace=cli_args.create_and_select_workspace,
+            exclude_file_patterns=exclude_file_patterns
         )
 
         # Output final config to stdout

--- a/terrat_runner/test_terragrunt_config_builder.py
+++ b/terrat_runner/test_terragrunt_config_builder.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import re
 import unittest
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
@@ -22,11 +23,11 @@ def _load_builder():
 builder = _load_builder()
 
 
-def generate(dirs, **kwargs):
+def generate(dirs, deps=None, **kwargs):
     return builder.generate_terrateam_config(
         {},
         dirs,
-        {d: {} for d in dirs},
+        deps if deps is not None else {d: {} for d in dirs},
         {},
         '/repo',
         **kwargs)
@@ -45,6 +46,27 @@ class ParseArgsTest(unittest.TestCase):
         args = builder.parse_args(['--scan-tf-files', '--no-create-and-select-workspace'])
         self.assertTrue(args.scan_tf_files)
         self.assertFalse(args.create_and_select_workspace)
+
+    def test_no_exclude_file_patterns_by_default(self):
+        # No flag: nothing is dropped from the generated file_patterns.
+        self.assertEqual(builder.parse_args([]).exclude_file_patterns, [])
+
+    def test_exclude_file_pattern_repeats(self):
+        args = builder.parse_args([
+            '--exclude-file-pattern', 'provider*.hcl',
+            '--exclude-file-pattern', 'provisioning/modules/**'])
+        self.assertEqual(
+            args.exclude_file_patterns,
+            ['provider*.hcl', 'provisioning/modules/**'])
+
+    def test_exclude_file_pattern_composes_with_the_other_flags(self):
+        args = builder.parse_args([
+            '--scan-tf-files',
+            '--no-create-and-select-workspace',
+            '--exclude-file-pattern', 'root.hcl'])
+        self.assertTrue(args.scan_tf_files)
+        self.assertFalse(args.create_and_select_workspace)
+        self.assertEqual(args.exclude_file_patterns, ['root.hcl'])
 
 
 class GenerateConfigTest(unittest.TestCase):
@@ -70,6 +92,185 @@ class GenerateConfigTest(unittest.TestCase):
         self.assertEqual(disabled, enabled)
 
 
+class GlobToRegexTest(unittest.TestCase):
+    def matches(self, glob, path):
+        return bool(re.match(builder.glob_to_regex(glob), path))
+
+    def test_star_stops_at_a_separator(self):
+        self.assertTrue(self.matches('provider*.hcl', 'provider_aws.hcl'))
+        self.assertFalse(self.matches('a/*/c.hcl', 'a/b/x/c.hcl'))
+
+    def test_double_star_spans_separators(self):
+        self.assertTrue(self.matches('provisioning/modules/**', 'provisioning/modules/vpc/main.tf'))
+
+    def test_leading_double_star_matches_a_bare_name(self):
+        # '**/root.hcl' has to match 'root.hcl' as well as 'a/b/root.hcl'.
+        self.assertTrue(self.matches('**/root.hcl', 'root.hcl'))
+        self.assertTrue(self.matches('**/root.hcl', 'a/b/root.hcl'))
+
+    def test_question_mark_is_one_character(self):
+        self.assertTrue(self.matches('a?c.hcl', 'abc.hcl'))
+        self.assertFalse(self.matches('a?c.hcl', 'abbc.hcl'))
+
+    def test_the_match_is_anchored_at_both_ends(self):
+        self.assertFalse(self.matches('root.hcl', 'a/root.hcl'))
+        self.assertFalse(self.matches('root.hcl', 'root.hcl.bak'))
+
+    def test_regex_metacharacters_are_literal(self):
+        self.assertTrue(self.matches('${DIR}/terragrunt.hcl', '${DIR}/terragrunt.hcl'))
+        self.assertFalse(self.matches('a.hcl', 'axhcl'))
+
+
+class MatchesExcludeTest(unittest.TestCase):
+    def test_a_bare_name_glob_matches_the_file_name_anywhere(self):
+        self.assertTrue(builder.matches_exclude('a/b/provider.hcl', ['provider*.hcl']))
+        self.assertTrue(builder.matches_exclude('provider.hcl', ['provider*.hcl']))
+
+    def test_a_path_glob_matches_the_repo_relative_path(self):
+        self.assertTrue(
+            builder.matches_exclude('provisioning/modules/vpc/main.tf', ['provisioning/modules/**']))
+        self.assertFalse(
+            builder.matches_exclude('other/modules/vpc/main.tf', ['provisioning/modules/**']))
+
+    def test_no_globs_never_matches(self):
+        self.assertFalse(builder.matches_exclude('root.hcl', []))
+
+    def test_any_one_glob_is_enough(self):
+        self.assertTrue(builder.matches_exclude('root.hcl', ['nope.hcl', 'root.hcl']))
+
+    def test_it_does_not_warn_per_pattern(self):
+        # Unusable globs are reported once by validate_exclude_globs; this runs
+        # per file_pattern per dir and has to stay quiet.
+        with mock.patch.object(builder, 'log') as log:
+            builder.matches_exclude('root.hcl', ['', '{a,b}.hcl', 'root.hcl'])
+        log.assert_not_called()
+
+
+class ValidateExcludeGlobsTest(unittest.TestCase):
+    def validate(self, globs):
+        with mock.patch.object(builder, 'log') as log:
+            kept = builder.validate_exclude_globs(globs)
+        return kept, [c.args[0] for c in log.call_args_list if c.args[1] == 'WARN']
+
+    def test_usable_globs_pass_through_quietly(self):
+        globs = ['provider*.hcl', 'provisioning/modules/**', 'a?c.hcl']
+        self.assertEqual(self.validate(globs), (globs, []))
+
+    def test_nothing_to_validate(self):
+        self.assertEqual(self.validate([]), ([], []))
+
+    def test_an_empty_glob_is_dropped_and_warned_once(self):
+        kept, warnings = self.validate(['', 'root.hcl'])
+        self.assertEqual(kept, ['root.hcl'])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('empty', warnings[0])
+
+    def test_each_empty_glob_warns_once(self):
+        kept, warnings = self.validate(['', ''])
+        self.assertEqual(kept, [])
+        self.assertEqual(len(warnings), 2)
+
+    def test_untranslated_syntax_is_kept_but_called_out(self):
+        # Path_glob understands these; glob_to_regex does not, so the user has
+        # to hear about it rather than silently keeping the fan-out.
+        for glob in ['{root,provider}.hcl', 'root.[hj]cl', '!root.hcl']:
+            kept, warnings = self.validate([glob])
+            self.assertEqual(kept, [glob])
+            self.assertEqual(len(warnings), 1, glob)
+            self.assertIn(repr(glob), warnings[0])
+
+    def test_a_plain_glob_is_not_called_out(self):
+        for glob in ['provider*.hcl', '**/root.hcl', '${DIR}/terragrunt.hcl',
+                     '${DIR}/${WORKSPACE}.tfvars']:
+            self.assertEqual(self.validate([glob])[1], [], glob)
+
+
+class ApplyExclusionsTest(unittest.TestCase):
+    patterns = [
+        '${DIR}/terragrunt.hcl',
+        '${DIR}/*.tf',
+        'root.hcl',
+        'provider.hcl',
+        'provisioning/modules/vpc/**/*.tf',
+        'prod/db/terragrunt.hcl',
+    ]
+
+    def apply(self, globs, dir_path='prod/app'):
+        with mock.patch.object(builder, 'log') as log:
+            kept = builder.apply_exclusions(list(self.patterns), globs, dir_path)
+        warnings = [c.args[0] for c in log.call_args_list if c.args[1] == 'WARN']
+        return kept, warnings
+
+    def test_no_globs_keeps_every_pattern(self):
+        kept, warnings = self.apply([])
+        self.assertEqual(kept, self.patterns)
+        self.assertEqual(warnings, [])
+
+    def test_a_shared_include_is_dropped_and_the_rest_kept(self):
+        kept, warnings = self.apply(['root.hcl'])
+        self.assertNotIn('root.hcl', kept)
+        self.assertEqual(kept, [p for p in self.patterns if p != 'root.hcl'])
+        self.assertEqual(warnings, [])
+
+    def test_order_is_preserved(self):
+        kept, _ = self.apply(['provider*.hcl'])
+        self.assertEqual(kept, [p for p in self.patterns if p != 'provider.hcl'])
+
+    def test_dropping_the_units_own_terragrunt_hcl_warns(self):
+        kept, warnings = self.apply(['terragrunt.hcl'])
+        self.assertNotIn('${DIR}/terragrunt.hcl', kept)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('autoplan', warnings[0])
+        self.assertIn('prod/app', warnings[0])
+
+    def test_the_root_unit_is_named_in_the_warning(self):
+        _, warnings = self.apply(['terragrunt.hcl'], dir_path='')
+        self.assertIn('from .;', warnings[0])
+
+    def test_dropping_everything_warns_too(self):
+        kept, warnings = self.apply(['**'])
+        self.assertEqual(kept, [])
+        self.assertEqual(len(warnings), 2)
+        self.assertIn('every file_pattern', warnings[1])
+
+
+class GenerateConfigExclusionsTest(unittest.TestCase):
+    deps = {
+        'prod/app': {'includes': ['root.hcl', 'provider.hcl']},
+        'prod/vpc': {'includes': ['root.hcl', 'provider.hcl']},
+    }
+
+    def file_patterns(self, **kwargs):
+        config = generate(list(self.deps), deps=self.deps, **kwargs)
+        return {d: config['dirs'][d]['when_modified']['file_patterns'] for d in self.deps}
+
+    def test_nothing_is_dropped_by_default(self):
+        for patterns in self.file_patterns().values():
+            self.assertIn('root.hcl', patterns)
+            self.assertIn('provider.hcl', patterns)
+
+    def test_an_empty_list_is_the_same_as_no_flag(self):
+        self.assertEqual(self.file_patterns(exclude_file_patterns=[]), self.file_patterns())
+
+    def test_a_shared_include_is_dropped_from_every_unit(self):
+        for patterns in self.file_patterns(exclude_file_patterns=['root.hcl']).values():
+            self.assertNotIn('root.hcl', patterns)
+            self.assertIn('provider.hcl', patterns)
+            self.assertIn('${DIR}/terragrunt.hcl', patterns)
+
+    def test_the_rest_of_the_dir_entry_is_unchanged(self):
+        plain = generate(list(self.deps), deps=self.deps)['dirs']['prod/app']
+        excluded = generate(
+            list(self.deps),
+            deps=self.deps,
+            exclude_file_patterns=['root.hcl'])['dirs']['prod/app']
+        self.assertNotEqual(
+            excluded['when_modified']['file_patterns'],
+            plain['when_modified']['file_patterns'])
+        excluded['when_modified'] = plain['when_modified']
+        self.assertEqual(excluded, plain)
+
+
 class MainTest(unittest.TestCase):
     def run_main(self, argv):
         stdout = io.StringIO()
@@ -93,6 +294,25 @@ class MainTest(unittest.TestCase):
     def test_no_flag_leaves_stdout_alone(self):
         config = self.run_main([])
         self.assertNotIn('create_and_select_workspace', config['dirs']['prod/vpc'])
+
+    def test_exclude_file_pattern_reaches_stdout(self):
+        config = self.run_main(['--exclude-file-pattern', 'terragrunt.hcl'])
+        patterns = config['dirs']['prod/vpc']['when_modified']['file_patterns']
+        self.assertNotIn('${DIR}/terragrunt.hcl', patterns)
+        self.assertIn('${DIR}/*.tf', patterns)
+
+    def test_no_exclude_file_pattern_leaves_stdout_alone(self):
+        patterns = self.run_main([])['dirs']['prod/vpc']['when_modified']['file_patterns']
+        self.assertEqual(patterns, ['${DIR}/terragrunt.hcl', '${DIR}/*.tf', '${DIR}/*.tfvars'])
+
+    def test_an_empty_glob_never_reaches_the_dirs(self):
+        with mock.patch.object(builder, 'log', wraps=builder.log) as log:
+            config = self.run_main(['--exclude-file-pattern', '', '--exclude-file-pattern', 'terragrunt.hcl'])
+        warnings = [c.args[0] for c in log.call_args_list if c.args[1:] == ('WARN',)]
+        self.assertEqual(len([w for w in warnings if 'empty' in w]), 1)
+        self.assertNotIn(
+            '${DIR}/terragrunt.hcl',
+            config['dirs']['prod/vpc']['when_modified']['file_patterns'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes stategraph/mono#2044

## What

Adds an opt-in, repeatable `--exclude-file-pattern GLOB` flag to `bin/terragrunt-config-builder`. Any generated `file_pattern` matching a glob is dropped from the `dirs` entry.

```yaml
config_builder:
  enabled: true
  script: terragrunt-config-builder --exclude-file-pattern 'provider*.hcl' --exclude-file-pattern 'provisioning/modules/**'
```

The `config_builder.script` field runs as a bash script, so arguments work. The flag composes with `--scan-tf-files` and `--no-create-and-select-workspace`.

## Why

Every file a unit reads becomes a `file_pattern`, and that includes shared ones. A parent `terragrunt.hcl` or a `provider.hcl` pulled in through `include` lands in the `file_patterns` of every generated dir, so editing one line in it autoplans the whole repo. Same for a shared module directory most units reach through `terraform.source`.

## Glob dialect

Same dialect as `file_patterns`: `**` spans directory separators, `*` and `?` stop at one, and the match is anchored at both ends.

- A glob with **no `/`** matches the file name alone, so `provider*.hcl` drops that file wherever it sits.
- Any other glob matches the **repo-relative path**, so `provisioning/modules/**` drops only what lives under that directory.

`pathlib.PurePath.match` can't be used here: before Python 3.13 it reads `**` as a single component, so `provisioning/modules/**` would quietly match nothing. Hence `glob_to_regex`.

## Warnings

A unit that no longer watches its own `terragrunt.hcl` can never autoplan, and that failure is silent at run time, so it's loud here instead. Two `WARN`s: exclusions that drop `${DIR}/terragrunt.hcl`, and exclusions that empty a unit's `file_patterns` entirely.

## Behavior

- Without the flag the generated `dirs` entries are byte-for-byte what they were before, and `--exclude-file-pattern` with an empty list is the same as no flag.
- With the flag only `when_modified.file_patterns` changes. Order of the surviving patterns is preserved; nothing else in the entry moves.

## Tests

26 new tests in `terrat_runner/test_terragrunt_config_builder.py` over `parse_args`, `glob_to_regex`, `matches_exclude`, `apply_exclusions`, `generate_terrateam_config`, and `main` (argv through to the JSON on stdout).

```
$ cd terrat_runner && python3 -m unittest discover -p 'test_*.py'
Ran 57 tests in 0.014s
OK
```

Mutation-checked twice: making `apply_exclusions` a no-op fails 8 tests, and confining `**` to a single path component fails 3. Reverting each returns the suite to green.
