### PR TITLE
#668 FIX Narrow the init lock to the toolchain install

### DIFF
--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -1,9 +1,34 @@
 import engine_tf
+import logging
 import re
 import subprocess
 
 
 CLI_REDESIGN_VERSION = (0, 88, 0)
+
+# Terragrunt's provider cache server, added in v0.56.4, downloads each provider
+# once and serves every unit from a local registry. That makes concurrent init
+# safe, so the init lock can be dropped -- it otherwise serialises each unit's
+# source and module fetching too, none of which contends.
+#
+# Opt-in only. Providers served from the cache server install as
+# `(unauthenticated)`: the recorded hashes still go into .terraform.lock.hcl and
+# are verified on every later init, so integrity holds, but the signature is not
+# checked against the origin registry on first install. That is the operator's
+# call, so we act only when they ask for it.
+PROVIDER_CACHE_VERSION = (0, 56, 4)
+
+# Both spellings are recognised because the TG_ prefix replaced TERRAGRUNT_ in
+# the CLI redesign.
+PROVIDER_CACHE_ENV_VARS = ('TG_PROVIDER_CACHE', 'TERRAGRUNT_PROVIDER_CACHE')
+
+
+def _is_enabled(value):
+    return value is not None and str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _provider_cache_requested(env):
+    return any(_is_enabled(env.get(k)) for k in PROVIDER_CACHE_ENV_VARS)
 
 
 def _parse_version(version):
@@ -22,6 +47,10 @@ class Engine(engine_tf.Engine):
         super().__init__(name, override_tf_cmd, **options)
         self.version = options.get('version')
         self.__use_run_for_workspace = None
+        # None means unresolved. The resolved value is always a 2-tuple, and
+        # unlike an object() sentinel this survives being pickled into a
+        # multiprocessing worker, which is how every dirspace gets its engine.
+        self.__resolved_version = None
 
     def _detect_installed_version(self, state):
         try:
@@ -36,24 +65,56 @@ class Engine(engine_tf.Engine):
 
         return _parse_version('\n'.join([proc.stdout, proc.stderr]))
 
+    def _resolve_version(self, state):
+        if self.__resolved_version is None:
+            version = self.version or state.workflow.get('engine', {}).get('version')
+            if version is None:
+                version = state.env.get('TG_DEFAULT_VERSION')
+
+            parsed_version = _parse_version(version)
+            if parsed_version is None:
+                # Safe to shell out by now: init installs the toolchain under
+                # the lock before anything asks for a version.
+                parsed_version = self._detect_installed_version(state)
+
+            self.__resolved_version = (parsed_version, version)
+
+        return self.__resolved_version
+
+    def _at_least(self, state, minimum):
+        (parsed_version, version) = self._resolve_version(state)
+
+        if parsed_version is None:
+            # An unparseable version is only assumed new enough when it names a
+            # moving target.
+            return str(version).lower() in ['latest', 'current']
+
+        return parsed_version >= minimum
+
     def _use_run_for_workspace(self, state):
-        if self.__use_run_for_workspace is not None:
-            return self.__use_run_for_workspace
-
-        version = self.version or state.workflow.get('engine', {}).get('version')
-        if version is None:
-            version = state.env.get('TG_DEFAULT_VERSION')
-
-        parsed_version = _parse_version(version)
-        if parsed_version is None:
-            parsed_version = self._detect_installed_version(state)
-
-        if parsed_version is None:
-            self.__use_run_for_workspace = str(version).lower() in ['latest', 'current']
-        else:
-            self.__use_run_for_workspace = parsed_version >= CLI_REDESIGN_VERSION
+        if self.__use_run_for_workspace is None:
+            self.__use_run_for_workspace = self._at_least(state, CLI_REDESIGN_VERSION)
 
         return self.__use_run_for_workspace
+
+    def lock_init(self, state):
+        if not _provider_cache_requested(state.env):
+            return True
+
+        if self._at_least(state, PROVIDER_CACHE_VERSION):
+            return False
+
+        # Asked for, but this Terragrunt will ignore the flag. Unlocking init
+        # here would leave concurrent inits racing in the shared plugin cache
+        # with nothing protecting them, so keep the lock and say why.
+        logging.warning(
+            ('INIT : PROVIDER_CACHE : %s : '
+             'requested but Terragrunt %r predates v%s, keeping the init lock'),
+            state.path,
+            self._resolve_version(state)[1],
+            '.'.join(str(p) for p in PROVIDER_CACHE_VERSION))
+
+        return True
 
     def workspace_cmd(self, state, *args):
         if self._use_run_for_workspace(state):

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -17,14 +17,20 @@ CLI_REDESIGN_VERSION = (0, 88, 0)
 # checked against the origin registry on first install. That is the operator's
 # call, so we act only when they ask for it.
 #
-# The request has two spellings, and each is read from a different version on.
+# The request has two spellings, each read over a different version range.
 # Verified by running every release from 0.50.0 through 1.1.4 with each one set
-# (terrateamio/action#668): the legacy name is still honoured on 1.1.4, only
-# with a deprecation warning. On a version that reads TG_PROVIDER_CACHE its
+# (terrateamio/action#668). On a version that reads TG_PROVIDER_CACHE its
 # value, even a false one, wins over the legacy name.
-PROVIDER_CACHE_FLOORS = (
-    ('TG_PROVIDER_CACHE', (0, 73, 0)),
-    ('TERRAGRUNT_PROVIDER_CACHE', (0, 56, 4)),
+#
+# The legacy name has warned "will be removed in a future version" since
+# 0.73.0. It is still honoured on 1.1.4, but the day it goes, a legacy-only
+# request would unlock init with no cache server behind it, so it is trusted
+# only as far as it has been verified. Beyond that the lock stays and the
+# warning says which spelling to use instead.
+PROVIDER_CACHE_SPELLINGS = (
+    # (name, first version that reads it, last version verified to read it)
+    ('TG_PROVIDER_CACHE', (0, 73, 0), None),
+    ('TERRAGRUNT_PROVIDER_CACHE', (0, 56, 4), (1, 1, 4)),
 )
 
 # Terragrunt parses these with Go's strconv.ParseBool. Anything else, such as
@@ -34,16 +40,19 @@ _TRUE = ('1', 't', 'T', 'true', 'True', 'TRUE')
 
 
 def _requested(env):
-    return any(env.get(name) in _TRUE for (name, _) in PROVIDER_CACHE_FLOORS)
+    return any(env.get(name) in _TRUE for (name, _, _) in PROVIDER_CACHE_SPELLINGS)
 
 
 def _cache_server_will_run(env, version):
     # Mirrors Terragrunt's own precedence, so this says whether *this* binary
     # will start the cache server, not whether the operator meant it to.
-    for (name, floor) in PROVIDER_CACHE_FLOORS:
+    for (name, floor, ceiling) in PROVIDER_CACHE_SPELLINGS:
         # Present but empty behaves as unset and falls through, as it does in
         # Terragrunt (tested on 0.77.9).
         if version >= floor and env.get(name, '') != '':
+            if ceiling is not None and version > ceiling:
+                return False
+
             return env[name] in _TRUE
 
     return False
@@ -157,10 +166,13 @@ class Engine(engine_tf.Engine):
             # them, so nothing short of certainty unlocks.
             logging.warning(
                 ('INIT : PROVIDER_CACHE : %s : '
-                 'requested but Terragrunt %s will not start the cache server '
-                 'with this setting, keeping the init lock'),
+                 'requested but Terragrunt %s is not known to start the cache '
+                 'server with this setting, keeping the init lock '
+                 '(TG_PROVIDER_CACHE is read from 0.73.0; TERRAGRUNT_PROVIDER_CACHE '
+                 'from 0.56.4 and verified through %s)'),
                 state.path,
-                _fmt(detected))
+                _fmt(detected),
+                _fmt(PROVIDER_CACHE_SPELLINGS[1][2]))
 
             return True
 

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -53,9 +53,13 @@ class Engine(engine_tf.Engine):
         self.__resolved_version = None
 
     def _detect_installed_version(self, state):
+        # Asking tenv for the version installs the toolchain as a side effect,
+        # so this takes the same lock init would have taken. Without it, an
+        # unpinned version turns every dirspace's probe into a concurrent
+        # install, which is terrateam#393 all over again.
         try:
             proc = subprocess.run(
-                [self.tf_cmd, '--version'],
+                ['flock', engine_tf.INIT_LOCK, self.tf_cmd, '--version'],
                 cwd=state.working_dir,
                 env=state.env,
                 capture_output=True,

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -1,34 +1,52 @@
 import engine_tf
 import logging
 import re
-import subprocess
 
 
 CLI_REDESIGN_VERSION = (0, 88, 0)
 
-# Terragrunt's provider cache server, added in v0.56.4, downloads each provider
-# once and serves every unit from a local registry. That makes concurrent init
-# safe, so the init lock can be dropped -- it otherwise serialises each unit's
-# source and module fetching too, none of which contends.
+# Terragrunt's provider cache server downloads each provider once, under a
+# lock file shared by every Terragrunt process on the machine, and serves every
+# unit from a local registry. That makes concurrent init safe, so the init lock
+# can be dropped -- it otherwise serialises each unit's source and module
+# fetching too, none of which contends.
 #
-# Opt-in only. Providers served from the cache server install as
+# It is opt-in. Providers served from the cache server install as
 # `(unauthenticated)`: the recorded hashes still go into .terraform.lock.hcl and
 # are verified on every later init, so integrity holds, but the signature is not
 # checked against the origin registry on first install. That is the operator's
 # call, so we act only when they ask for it.
-PROVIDER_CACHE_VERSION = (0, 56, 4)
+#
+# The request has two spellings, and each is read from a different version on.
+# Verified by running every release from 0.50.0 through 1.1.4 with each one set
+# (terrateamio/action#668): the legacy name is still honoured on 1.1.4, only
+# with a deprecation warning. On a version that reads TG_PROVIDER_CACHE its
+# value, even a false one, wins over the legacy name.
+PROVIDER_CACHE_FLOORS = (
+    ('TG_PROVIDER_CACHE', (0, 73, 0)),
+    ('TERRAGRUNT_PROVIDER_CACHE', (0, 56, 4)),
+)
 
-# Both spellings are recognised because the TG_ prefix replaced TERRAGRUNT_ in
-# the CLI redesign.
-PROVIDER_CACHE_ENV_VARS = ('TG_PROVIDER_CACHE', 'TERRAGRUNT_PROVIDER_CACHE')
+# Terragrunt parses these with Go's strconv.ParseBool. Anything else, such as
+# 'yes' or 'on', makes it exit with "invalid value" before doing anything, so
+# treating those as a request would unlock init for a run that then fails.
+_TRUE = ('1', 't', 'T', 'true', 'True', 'TRUE')
 
 
-def _is_enabled(value):
-    return value is not None and str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+def _requested(env):
+    return any(env.get(name) in _TRUE for (name, _) in PROVIDER_CACHE_FLOORS)
 
 
-def _provider_cache_requested(env):
-    return any(_is_enabled(env.get(k)) for k in PROVIDER_CACHE_ENV_VARS)
+def _cache_server_will_run(env, version):
+    # Mirrors Terragrunt's own precedence, so this says whether *this* binary
+    # will start the cache server, not whether the operator meant it to.
+    for (name, floor) in PROVIDER_CACHE_FLOORS:
+        # Present but empty behaves as unset and falls through, as it does in
+        # Terragrunt (tested on 0.77.9).
+        if version >= floor and env.get(name, '') != '':
+            return env[name] in _TRUE
+
+    return False
 
 
 def _parse_version(version):
@@ -42,46 +60,47 @@ def _parse_version(version):
     return tuple(int(part) for part in match.groups())
 
 
+def _fmt(version):
+    return '.'.join(str(part) for part in version)
+
+
 class Engine(engine_tf.Engine):
     def __init__(self, name, override_tf_cmd, **options):
         super().__init__(name, override_tf_cmd, **options)
         self.version = options.get('version')
         self.__use_run_for_workspace = None
-        # None means unresolved. The resolved value is always a 2-tuple, and
-        # unlike an object() sentinel this survives being pickled into a
-        # multiprocessing worker, which is how every dirspace gets its engine.
+        # (parsed, configured) once known. None until then; a failed probe is
+        # never cached, so a later caller gets another chance after init has
+        # had its own go at installing the toolchain.
         self.__resolved_version = None
 
+    def _configured_version(self, state):
+        version = self.version or state.workflow.get('engine', {}).get('version')
+        if version is None:
+            version = state.env.get('TG_DEFAULT_VERSION')
+
+        return version
+
     def _detect_installed_version(self, state):
-        # Asking tenv for the version installs the toolchain as a side effect,
-        # so this takes the same lock init would have taken. Without it, an
-        # unpinned version turns every dirspace's probe into a concurrent
-        # install, which is terrateam#393 all over again.
-        try:
-            proc = subprocess.run(
-                ['flock', engine_tf.INIT_LOCK, self.tf_cmd, '--version'],
-                cwd=state.working_dir,
-                env=state.env,
-                capture_output=True,
-                text=True)
-        except OSError:
+        (returncode, stdout, stderr) = self.probe_toolchain(state, self.tf_cmd)
+
+        if returncode != 0:
             return None
 
-        return _parse_version('\n'.join([proc.stdout, proc.stderr]))
+        return _parse_version('\n'.join([stdout, stderr]))
 
     def _resolve_version(self, state):
         if self.__resolved_version is None:
-            version = self.version or state.workflow.get('engine', {}).get('version')
-            if version is None:
-                version = state.env.get('TG_DEFAULT_VERSION')
+            configured = self._configured_version(state)
+            parsed = _parse_version(configured)
 
-            parsed_version = _parse_version(version)
-            if parsed_version is None:
-                # Safe to shell out by now: init installs the toolchain under
-                # the lock before anything asks for a version.
-                parsed_version = self._detect_installed_version(state)
+            if parsed is None:
+                parsed = self._detect_installed_version(state)
 
-            self.__resolved_version = (parsed_version, version)
+                if parsed is None:
+                    return (None, configured)
+
+            self.__resolved_version = (parsed, configured)
 
         return self.__resolved_version
 
@@ -90,7 +109,7 @@ class Engine(engine_tf.Engine):
 
         if parsed_version is None:
             # An unparseable version is only assumed new enough when it names a
-            # moving target.
+            # moving target. A wrong guess here costs one failed command.
             return str(version).lower() in ['latest', 'current']
 
         return parsed_version >= minimum
@@ -102,23 +121,50 @@ class Engine(engine_tf.Engine):
         return self.__use_run_for_workspace
 
     def lock_init(self, state):
-        if not _provider_cache_requested(state.env):
+        env = state.env
+
+        if not _requested(env):
             return True
 
-        if self._at_least(state, PROVIDER_CACHE_VERSION):
-            return False
+        # Opted in. Unlocking init hands us the lock's other job, so install
+        # every binary init will reach, under the lock, before deciding
+        # anything: the tofu or terraform that Terragrunt shells out to, then
+        # Terragrunt itself. The second probe also tells us which Terragrunt is
+        # really going to run -- a configured version is only a tenv default,
+        # and a version file in the repository can quietly pick an older one.
+        underlying = env.get('TERRATEAM_TF_CMD')
+        if underlying:
+            self.probe_toolchain(state, underlying)
 
-        # Asked for, but this Terragrunt will ignore the flag. Unlocking init
-        # here would leave concurrent inits racing in the shared plugin cache
-        # with nothing protecting them, so keep the lock and say why.
-        logging.warning(
-            ('INIT : PROVIDER_CACHE : %s : '
-             'requested but Terragrunt %r predates v%s, keeping the init lock'),
-            state.path,
-            self._resolve_version(state)[1],
-            '.'.join(str(p) for p in PROVIDER_CACHE_VERSION))
+        detected = self._detect_installed_version(state)
 
-        return True
+        if detected is None:
+            logging.warning(
+                ('INIT : PROVIDER_CACHE : %s : '
+                 'requested but the Terragrunt version could not be determined, '
+                 'keeping the init lock'),
+                state.path)
+
+            return True
+
+        # The binary that will run is the one whose version matters, for the
+        # workspace command as well as for this decision.
+        self.__resolved_version = (detected, self._configured_version(state))
+
+        if not _cache_server_will_run(env, detected):
+            # A wrong guess here is not a failed command, it is concurrent
+            # inits racing in a shared plugin cache with nothing protecting
+            # them, so nothing short of certainty unlocks.
+            logging.warning(
+                ('INIT : PROVIDER_CACHE : %s : '
+                 'requested but Terragrunt %s will not start the cache server '
+                 'with this setting, keeping the init lock'),
+                state.path,
+                _fmt(detected))
+
+            return True
+
+        return False
 
     def workspace_cmd(self, state, *args):
         if self._use_run_for_workspace(state):

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -140,40 +140,38 @@ class Engine:
     def workspace_cmd(self, state, *args):
         return [self.tf_cmd, 'workspace'] + list(args)
 
-    def install_toolchain(self, state):
-        # tenv installs the pinned Terraform/Terragrunt the first time the
-        # command is run. Concurrent installs raced and could leave a dirspace
-        # with no binary at all, so serialise the install (terrateam#393).
-        # Asking for the version is enough to trigger it, and once it is
-        # installed this costs milliseconds, so only the first dirspace waits.
+    def probe_toolchain(self, state, tf_cmd):
+        # `<tf_cmd> --version`, under the init lock. Under tenv the first call
+        # installs the binary, and concurrent installs raced badly enough to
+        # leave a dirspace with no binary at all (terrateam#393). Once installed
+        # this costs milliseconds. Quiet on success; a failure is the only place
+        # the toolchain problem is visible, because init fails afterwards for
+        # what looks like an unrelated reason.
         (proc, stdout, stderr) = cmd.run_with_output(
             state,
             {
-                'cmd': ['flock', INIT_LOCK, self.tf_cmd, '--version'],
+                'cmd': ['flock', INIT_LOCK, tf_cmd, '--version'],
                 'log_output': False
             })
 
-        # Quiet on success -- this runs once per dirspace and the version is not
-        # interesting. On failure it is the only place the toolchain problem is
-        # visible, because `init` will fail afterwards for what looks like an
-        # unrelated reason.
         if proc.returncode != 0:
             logging.warning(
                 'INIT : TOOLCHAIN : %s : %s --version exited %d : %s',
                 state.path,
-                self.tf_cmd,
+                tf_cmd,
                 proc.returncode,
                 '\n'.join([stderr, stdout]).strip())
 
+        return (proc.returncode, stdout, stderr)
+
     def lock_init(self, state):
-        # Terraform does not lock TF_PLUGIN_CACHE_DIR: it unpacks a provider
-        # straight to its final path in the shared cache, so a concurrent init
-        # can link against a half-written binary, exit 0, and fail later with a
-        # checksum mismatch. Upstream has not fixed this
-        # (hashicorp/terraform#31964), and a shared cache can be configured out
-        # of band through the CLI config file as well as the environment, so
-        # serialising is the safe default. An engine overrides this only when it
-        # can guarantee concurrent init is safe.
+        # Whether init runs under the lock. The lock does two jobs at once: it
+        # serialises the tenv install of whichever binaries init reaches, and it
+        # keeps concurrent inits from corrupting a shared TF_PLUGIN_CACHE_DIR,
+        # which Terraform does not lock (hashicorp/terraform#31964). An engine
+        # that returns False takes both jobs on itself: it must have called
+        # probe_toolchain for every binary init will run, and it must know that
+        # concurrent init is safe for this configuration.
         return True
 
     def init(self, state, config, create_and_select_workspace=None):
@@ -182,17 +180,10 @@ class Engine:
         if os.path.exists(terraform_path):
             shutil.rmtree(terraform_path)
 
-        lock_init = self.lock_init(state)
-
         init_cmd = [self.tf_cmd, 'init'] + config.get('extra_args', [])
 
-        if lock_init:
-            # tenv installs inside this lock, which is what terrateam#393 was
-            # about, so nothing more is needed.
+        if self.lock_init(state):
             init_cmd = ['flock', INIT_LOCK] + init_cmd
-        else:
-            # Nothing else will serialise the install, so do it on its own.
-            self.install_toolchain(state)
 
         (proc, stdout, stderr) = retry.run(
             lambda: cmd.run_with_output(state, {'cmd': init_cmd}),

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -161,10 +161,11 @@ class Engine:
                 tf_cmd,
                 proc.returncode,
                 '\n'.join([stderr, stdout]).strip())
-        elif stderr.strip():
-            # tenv is silent when the binary is already there and reports on
-            # stderr when it installs, so this names the one dirspace that
-            # paid for the install and shows the others found it in place.
+        elif 'Installing' in stderr:
+            # tenv is silent when the binary is already there and says
+            # "Installing <tool> <version>" on stderr when it is not, so this
+            # names the one dirspace that paid for the install. The others
+            # only ever emit unrelated warnings from the tool itself.
             logging.info(
                 'INIT : TOOLCHAIN : %s : %s : %s',
                 state.path,

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -161,6 +161,15 @@ class Engine:
                 tf_cmd,
                 proc.returncode,
                 '\n'.join([stderr, stdout]).strip())
+        elif stderr.strip():
+            # tenv is silent when the binary is already there and reports on
+            # stderr when it installs, so this names the one dirspace that
+            # paid for the install and shows the others found it in place.
+            logging.info(
+                'INIT : TOOLCHAIN : %s : %s : %s',
+                state.path,
+                tf_cmd,
+                ' | '.join(stderr.strip().splitlines()))
 
         return (proc.returncode, stdout, stderr)
 

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -146,12 +146,24 @@ class Engine:
         # with no binary at all, so serialise the install (terrateam#393).
         # Asking for the version is enough to trigger it, and once it is
         # installed this costs milliseconds, so only the first dirspace waits.
-        cmd.run_with_output(
+        (proc, stdout, stderr) = cmd.run_with_output(
             state,
             {
                 'cmd': ['flock', INIT_LOCK, self.tf_cmd, '--version'],
                 'log_output': False
             })
+
+        # Quiet on success -- this runs once per dirspace and the version is not
+        # interesting. On failure it is the only place the toolchain problem is
+        # visible, because `init` will fail afterwards for what looks like an
+        # unrelated reason.
+        if proc.returncode != 0:
+            logging.warning(
+                'INIT : TOOLCHAIN : %s : %s --version exited %d : %s',
+                state.path,
+                self.tf_cmd,
+                proc.returncode,
+                '\n'.join([stderr, stdout]).strip())
 
     def lock_init(self, state):
         # Terraform does not lock TF_PLUGIN_CACHE_DIR: it unpacks a provider

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -182,12 +182,17 @@ class Engine:
         if os.path.exists(terraform_path):
             shutil.rmtree(terraform_path)
 
-        self.install_toolchain(state)
+        lock_init = self.lock_init(state)
 
         init_cmd = [self.tf_cmd, 'init'] + config.get('extra_args', [])
 
-        if self.lock_init(state):
+        if lock_init:
+            # tenv installs inside this lock, which is what terrateam#393 was
+            # about, so nothing more is needed.
             init_cmd = ['flock', INIT_LOCK] + init_cmd
+        else:
+            # Nothing else will serialise the install, so do it on its own.
+            self.install_toolchain(state)
 
         (proc, stdout, stderr) = retry.run(
             lambda: cmd.run_with_output(state, {'cmd': init_cmd}),

--- a/terrat_runner/engine_tf.py
+++ b/terrat_runner/engine_tf.py
@@ -12,6 +12,8 @@ TRIES = 3
 INITIAL_SLEEP = 1
 BACKOFF = 1.5
 
+INIT_LOCK = '/tmp/tf-init.lock'
+
 
 # Opens a Terraform heredoc string value, e.g. `foo = <<-EOT` or `foo =
 # <<EOT`, capturing the delimiter so we can find the matching closing line.
@@ -138,23 +140,45 @@ class Engine:
     def workspace_cmd(self, state, *args):
         return [self.tf_cmd, 'workspace'] + list(args)
 
+    def install_toolchain(self, state):
+        # tenv installs the pinned Terraform/Terragrunt the first time the
+        # command is run. Concurrent installs raced and could leave a dirspace
+        # with no binary at all, so serialise the install (terrateam#393).
+        # Asking for the version is enough to trigger it, and once it is
+        # installed this costs milliseconds, so only the first dirspace waits.
+        cmd.run_with_output(
+            state,
+            {
+                'cmd': ['flock', INIT_LOCK, self.tf_cmd, '--version'],
+                'log_output': False
+            })
+
+    def lock_init(self, state):
+        # Terraform does not lock TF_PLUGIN_CACHE_DIR: it unpacks a provider
+        # straight to its final path in the shared cache, so a concurrent init
+        # can link against a half-written binary, exit 0, and fail later with a
+        # checksum mismatch. Upstream has not fixed this
+        # (hashicorp/terraform#31964), and a shared cache can be configured out
+        # of band through the CLI config file as well as the environment, so
+        # serialising is the safe default. An engine overrides this only when it
+        # can guarantee concurrent init is safe.
+        return True
+
     def init(self, state, config, create_and_select_workspace=None):
         # If there is already a .terraform dir, delete it
         terraform_path = os.path.join(state.working_dir, '.terraform')
         if os.path.exists(terraform_path):
             shutil.rmtree(terraform_path)
 
+        self.install_toolchain(state)
+
+        init_cmd = [self.tf_cmd, 'init'] + config.get('extra_args', [])
+
+        if self.lock_init(state):
+            init_cmd = ['flock', INIT_LOCK] + init_cmd
+
         (proc, stdout, stderr) = retry.run(
-            lambda: cmd.run_with_output(
-                state,
-                {
-                    'cmd': [
-                        'flock',
-                        '/tmp/tf-init.lock',
-                        self.tf_cmd,
-                        'init'
-                    ] + config.get('extra_args', [])
-                }),
+            lambda: cmd.run_with_output(state, {'cmd': init_cmd}),
             retry.finite_tries(TRIES, lambda result: result[0].returncode == 0),
             retry.betwixt_sleep_with_backoff(INITIAL_SLEEP, BACKOFF))
 

--- a/terrat_runner/test_engine_cdktf.py
+++ b/terrat_runner/test_engine_cdktf.py
@@ -36,13 +36,7 @@ class InitDelegationTest(unittest.TestCase):
             self._sequence(),
             [['cdktf', 'get'],
              ['cdktf', 'synth'],
-             ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
              ['flock', engine_tf.INIT_LOCK, 'terraform', 'init']])
-
-    def test_cdktf_steps_come_before_the_toolchain_install(self):
-        seq = self._sequence()
-        self.assertLess(seq.index(['cdktf', 'synth']),
-                        seq.index(['flock', engine_tf.INIT_LOCK, 'terraform', '--version']))
 
     def test_init_is_still_locked_for_cdktf(self):
         self.assertIn(['flock', engine_tf.INIT_LOCK, 'terraform', 'init'], self._sequence())

--- a/terrat_runner/test_engine_cdktf.py
+++ b/terrat_runner/test_engine_cdktf.py
@@ -1,0 +1,48 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import engine_cdktf
+import engine_tf
+
+
+class InitDelegationTest(unittest.TestCase):
+    # engine_cdktf.Engine.init runs `cdktf get` and `cdktf synth` and then hands
+    # off to engine_tf.Engine.init, so it inherits the serialized toolchain
+    # install and the init lock. This asserts that handoff, because cdktf is the
+    # engine least likely to be exercised end to end.
+    #
+    # engine_cdktf and engine_tf share the same `cmd` module object, so one
+    # patch captures the whole sequence.
+    def _sequence(self):
+        state = SimpleNamespace(
+            path='cdktf/dir',
+            env={},
+            working_dir='/nonexistent',
+            workflow={'engine': {'name': 'tf'}},
+            repo_config={}
+        )
+        engine = engine_cdktf.make(override_tf_cmd='terraform')
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run, \
+             mock.patch('engine_cdktf._run', side_effect=lambda s, c, f: f(s, c)):
+            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+            engine.init(state, {})
+
+        return [c[0][1]['cmd'] for c in run.call_args_list]
+
+    def test_the_whole_init_sequence(self):
+        self.assertEqual(
+            self._sequence(),
+            [['cdktf', 'get'],
+             ['cdktf', 'synth'],
+             ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
+             ['flock', engine_tf.INIT_LOCK, 'terraform', 'init']])
+
+    def test_cdktf_steps_come_before_the_toolchain_install(self):
+        seq = self._sequence()
+        self.assertLess(seq.index(['cdktf', 'synth']),
+                        seq.index(['flock', engine_tf.INIT_LOCK, 'terraform', '--version']))
+
+    def test_init_is_still_locked_for_cdktf(self):
+        self.assertIn(['flock', engine_tf.INIT_LOCK, 'terraform', 'init'], self._sequence())

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -116,6 +116,22 @@ class VersionFloorTest(unittest.TestCase):
     def test_legacy_spelling_is_still_honoured_on_1_1_4(self):
         self.assertEqual(self._init_cmd({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v1.1.4'), UNLOCKED)
 
+    def test_legacy_spelling_is_not_trusted_past_what_was_verified(self):
+        # It has warned of removal since 0.73.0. A release that drops it would
+        # leave a legacy-only request unlocking init with no cache server, so
+        # newer than verified keeps the lock and the warning names the fix.
+        (calls, warn, _) = run_init({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'terragrunt version v1.2.0')
+        self.assertEqual(calls[-1], LOCKED)
+        self.assertIn('TG_PROVIDER_CACHE', ' '.join(str(a) for a in warn.call_args[0]))
+
+    def test_the_current_spelling_has_no_ceiling(self):
+        self.assertEqual(self._init_cmd({'TG_PROVIDER_CACHE': '1'}, 'v1.2.0'), UNLOCKED)
+
+    def test_a_current_spelling_present_on_a_new_version_still_beats_legacy(self):
+        self.assertEqual(
+            self._init_cmd({'TG_PROVIDER_CACHE': 'false', 'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v1.2.0'),
+            LOCKED)
+
 
 class PrecedenceTest(unittest.TestCase):
     # Verified against 0.77.9 and 1.1.4: a TG_ value that is present wins over

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -87,8 +87,7 @@ class InitCommandTest(unittest.TestCase):
     def test_default_is_unchanged_from_before(self):
         self.assertEqual(
             self._calls('0.77.9', {}),
-            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
-             ['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
+            [['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
 
     def test_opting_in_unlocks_init_but_not_the_install(self):
         self.assertEqual(
@@ -96,32 +95,37 @@ class InitCommandTest(unittest.TestCase):
             [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
              ['terragrunt', 'init']])
 
-    def test_an_old_version_keeps_both_locks(self):
+    def test_an_old_version_keeps_the_lock_and_adds_nothing(self):
         self.assertEqual(
             self._calls('0.50.0', {'TG_PROVIDER_CACHE': '1'}),
-            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
-             ['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
+            [['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
 
 
-class NoVersionProbeRaceTest(unittest.TestCase):
-    def test_the_version_is_probed_after_the_toolchain_install(self):
-        # _detect_installed_version shells out to `terragrunt --version`, which
-        # with TENV_AUTO_INSTALL is itself an install. It must not run before
-        # the serialised install has happened.
+class VersionProbeRaceTest(unittest.TestCase):
+    # _detect_installed_version shells out to `<tf_cmd> --version`, which under
+    # TENV_AUTO_INSTALL is itself an install. It runs before init has taken any
+    # lock, so it has to take one itself.
+    def test_version_detection_is_serialised(self):
         engine = engine_terragrunt.make()
-        order = []
+        captured = {}
 
-        with mock.patch('engine_tf.cmd.run_with_output') as run:
-            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
-            run.side_effect = lambda s, c: (order.append(c['cmd'][-1]),
-                                            (SimpleNamespace(returncode=0), 'o', 'e'))[1]
-            with mock.patch.object(engine_terragrunt.Engine, '_detect_installed_version',
-                                   side_effect=lambda s: order.append('probe')):
-                with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
-                                return_value=False):
-                    engine.init(state({'TG_PROVIDER_CACHE': '1'}), {})
+        def fake_run(cmd, **kwargs):
+            captured['cmd'] = cmd
+            return SimpleNamespace(returncode=0, stdout='terragrunt version v0.77.9', stderr='')
 
-        self.assertEqual(order.index('--version') < order.index('probe'), True)
+        with mock.patch('engine_terragrunt.subprocess.run', side_effect=fake_run):
+            engine._detect_installed_version(state())
+
+        self.assertEqual(captured['cmd'][:2], ['flock', engine_tf.INIT_LOCK])
+        self.assertEqual(captured['cmd'][-1], '--version')
+
+    def test_an_unpinned_opted_in_engine_still_resolves(self):
+        engine = engine_terragrunt.make()
+
+        with mock.patch('engine_terragrunt.subprocess.run') as run:
+            run.return_value = SimpleNamespace(
+                returncode=0, stdout='terragrunt version v0.77.9', stderr='')
+            self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'})))
 
 
 if __name__ == '__main__':

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -1,0 +1,128 @@
+import pickle
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import engine_terragrunt
+import engine_tf
+
+
+def state(env=None, version=None):
+    return SimpleNamespace(
+        path='dir/space',
+        env=env if env is not None else {},
+        working_dir='/nonexistent',
+        workflow={'engine': {'name': 'tf', 'version': version}},
+        repo_config={}
+    )
+
+
+class LockInitTest(unittest.TestCase):
+    def _lock(self, version, env=None):
+        return engine_terragrunt.make(version=version).lock_init(state(env, version))
+
+    def test_locked_when_the_cache_was_not_asked_for(self):
+        self.assertTrue(self._lock('0.77.9'))
+
+    def test_locked_when_the_cache_is_turned_off(self):
+        self.assertTrue(self._lock('0.77.9', {'TG_PROVIDER_CACHE': 'false'}))
+
+    def test_unlocked_when_asked_for_on_a_supported_version(self):
+        self.assertFalse(self._lock('0.77.9', {'TG_PROVIDER_CACHE': '1'}))
+
+    def test_the_introducing_version_is_supported(self):
+        self.assertFalse(self._lock('v0.56.4', {'TG_PROVIDER_CACHE': '1'}))
+
+    def test_one_patch_earlier_is_vetoed(self):
+        # The flag would be ignored by this Terragrunt, so unlocking init would
+        # leave concurrent inits racing with nothing protecting them.
+        self.assertTrue(self._lock('0.56.3', {'TG_PROVIDER_CACHE': '1'}))
+
+    def test_the_legacy_spelling_is_honoured(self):
+        self.assertFalse(self._lock('0.77.9', {'TERRAGRUNT_PROVIDER_CACHE': 'true'}))
+
+    def test_latest_is_assumed_new_enough(self):
+        self.assertFalse(self._lock('latest', {'TG_PROVIDER_CACHE': '1'}))
+
+    def test_the_veto_is_warned_about_once(self):
+        engine = engine_terragrunt.make(version='0.50.0')
+        st = state({'TG_PROVIDER_CACHE': '1'}, '0.50.0')
+        with mock.patch('engine_terragrunt.logging.warning') as warn:
+            engine.lock_init(st)
+        self.assertEqual(warn.call_count, 1)
+
+
+class PickleTest(unittest.TestCase):
+    # Every dirspace gets its engine by pickling the run state into a
+    # multiprocessing worker, so cached state has to survive the round trip.
+    def test_an_engine_survives_a_round_trip_before_resolving(self):
+        engine = pickle.loads(pickle.dumps(engine_terragrunt.make(version='0.77.9')))
+        self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9')))
+
+    def test_an_engine_survives_a_round_trip_after_resolving(self):
+        engine = engine_terragrunt.make(version='0.77.9')
+        engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9'))
+        engine = pickle.loads(pickle.dumps(engine))
+        self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9')))
+
+    def test_workspace_selection_survives_a_round_trip(self):
+        engine = pickle.loads(pickle.dumps(engine_terragrunt.make(version='0.77.9')))
+        self.assertEqual(
+            engine.workspace_cmd(state(version='0.77.9'), 'select', 'default'),
+            ['terragrunt', 'workspace', 'select', 'default'])
+
+
+class InitCommandTest(unittest.TestCase):
+    def _calls(self, version, env):
+        engine = engine_terragrunt.make(version=version)
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+            with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
+                            return_value=False):
+                engine.init(state(env, version), {})
+
+        return [c[0][1]['cmd'] for c in run.call_args_list]
+
+    def test_default_is_unchanged_from_before(self):
+        self.assertEqual(
+            self._calls('0.77.9', {}),
+            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
+             ['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
+
+    def test_opting_in_unlocks_init_but_not_the_install(self):
+        self.assertEqual(
+            self._calls('0.77.9', {'TG_PROVIDER_CACHE': '1'}),
+            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
+             ['terragrunt', 'init']])
+
+    def test_an_old_version_keeps_both_locks(self):
+        self.assertEqual(
+            self._calls('0.50.0', {'TG_PROVIDER_CACHE': '1'}),
+            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
+             ['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
+
+
+class NoVersionProbeRaceTest(unittest.TestCase):
+    def test_the_version_is_probed_after_the_toolchain_install(self):
+        # _detect_installed_version shells out to `terragrunt --version`, which
+        # with TENV_AUTO_INSTALL is itself an install. It must not run before
+        # the serialised install has happened.
+        engine = engine_terragrunt.make()
+        order = []
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+            run.side_effect = lambda s, c: (order.append(c['cmd'][-1]),
+                                            (SimpleNamespace(returncode=0), 'o', 'e'))[1]
+            with mock.patch.object(engine_terragrunt.Engine, '_detect_installed_version',
+                                   side_effect=lambda s: order.append('probe')):
+                with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
+                                return_value=False):
+                    engine.init(state({'TG_PROVIDER_CACHE': '1'}), {})
+
+        self.assertEqual(order.index('--version') < order.index('probe'), True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -17,115 +17,202 @@ def state(env=None, version=None):
     )
 
 
-class LockInitTest(unittest.TestCase):
-    def _lock(self, version, env=None):
-        return engine_terragrunt.make(version=version).lock_init(state(env, version))
+class Toolchain:
+    # Stands in for cmd.run_with_output. Answers `--version` per binary the
+    # way tenv-installed ones do, records every command, and lets a probe fail.
+    def __init__(self, terragrunt='terragrunt version v0.77.9', terragrunt_rc=0):
+        self.terragrunt = terragrunt
+        self.terragrunt_rc = terragrunt_rc
+        self.calls = []
 
-    def test_locked_when_the_cache_was_not_asked_for(self):
-        self.assertTrue(self._lock('0.77.9'))
+    def __call__(self, st, config):
+        cmd = config['cmd']
+        self.calls.append(cmd)
 
-    def test_locked_when_the_cache_is_turned_off(self):
-        self.assertTrue(self._lock('0.77.9', {'TG_PROVIDER_CACHE': 'false'}))
+        if cmd[-1] == '--version':
+            if cmd[-2] == 'terragrunt':
+                return (SimpleNamespace(returncode=self.terragrunt_rc), self.terragrunt, '')
+            return (SimpleNamespace(returncode=0), 'OpenTofu v1.6.3', '')
 
-    def test_unlocked_when_asked_for_on_a_supported_version(self):
-        self.assertFalse(self._lock('0.77.9', {'TG_PROVIDER_CACHE': '1'}))
+        return (SimpleNamespace(returncode=0), 'out', 'err')
 
-    def test_the_introducing_version_is_supported(self):
-        self.assertFalse(self._lock('v0.56.4', {'TG_PROVIDER_CACHE': '1'}))
 
-    def test_one_patch_earlier_is_vetoed(self):
-        # The flag would be ignored by this Terragrunt, so unlocking init would
-        # leave concurrent inits racing with nothing protecting them.
-        self.assertTrue(self._lock('0.56.3', {'TG_PROVIDER_CACHE': '1'}))
+def run_init(env, binary='terragrunt version v0.77.9', rc=0, version=None):
+    toolchain = Toolchain(binary, rc)
+    engine = engine_terragrunt.make(version=version)
 
-    def test_the_legacy_spelling_is_honoured(self):
-        self.assertFalse(self._lock('0.77.9', {'TERRAGRUNT_PROVIDER_CACHE': 'true'}))
+    with mock.patch('engine_tf.cmd.run_with_output', side_effect=toolchain):
+        with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
+                        return_value=False):
+            with mock.patch('engine_terragrunt.logging.warning') as warn:
+                engine.init(state(dict(env), version), {})
 
-    def test_latest_is_assumed_new_enough(self):
-        self.assertFalse(self._lock('latest', {'TG_PROVIDER_CACHE': '1'}))
+    return (toolchain.calls, warn, engine)
 
-    def test_the_veto_is_warned_about_once(self):
-        engine = engine_terragrunt.make(version='0.50.0')
-        st = state({'TG_PROVIDER_CACHE': '1'}, '0.50.0')
-        with mock.patch('engine_terragrunt.logging.warning') as warn:
-            engine.lock_init(st)
+
+LOCKED = ['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']
+UNLOCKED = ['terragrunt', 'init']
+PROBE_TG = ['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version']
+PROBE_TOFU = ['flock', engine_tf.INIT_LOCK, 'tofu', '--version']
+OPTED_IN = {'TG_PROVIDER_CACHE': '1', 'TERRATEAM_TF_CMD': 'tofu'}
+
+
+class DefaultPathTest(unittest.TestCase):
+    def test_nothing_set_is_byte_identical_to_before(self):
+        (calls, warn, _) = run_init({})
+        self.assertEqual(calls, [LOCKED])
+        self.assertEqual(warn.call_count, 0)
+
+    def test_a_value_terragrunt_would_reject_is_not_a_request(self):
+        # 'yes' and 'on' make Terragrunt exit with "invalid value", so the safe
+        # thing is the default path, where init reports that error itself.
+        for value in ('yes', 'on', 'false', '0', ''):
+            (calls, _, _) = run_init({'TG_PROVIDER_CACHE': value, 'TERRATEAM_TF_CMD': 'tofu'})
+            self.assertEqual(calls, [LOCKED], value)
+
+
+class OptInTest(unittest.TestCase):
+    def test_both_binaries_are_installed_under_the_lock_before_init(self):
+        # Terragrunt shells out to tofu/terraform, which tenv installs on first
+        # use. Unlocked, that install would race across dirspaces
+        # (terrateam#393), so both are probed under the lock first, and in
+        # that order.
+        (calls, warn, _) = run_init(OPTED_IN)
+        self.assertEqual(calls, [PROBE_TOFU, PROBE_TG, UNLOCKED])
+        self.assertEqual(warn.call_count, 0)
+
+    def test_without_an_underlying_command_only_terragrunt_is_probed(self):
+        (calls, _, _) = run_init({'TG_PROVIDER_CACHE': '1'})
+        self.assertEqual(calls, [PROBE_TG, UNLOCKED])
+
+    def test_every_spelling_go_parsebool_accepts(self):
+        for value in ('1', 't', 'T', 'true', 'True', 'TRUE'):
+            (calls, _, _) = run_init({'TG_PROVIDER_CACHE': value})
+            self.assertEqual(calls[-1], UNLOCKED, value)
+
+
+class VersionFloorTest(unittest.TestCase):
+    # Floors come from running every release 0.50.0 -> 1.1.4 with each spelling
+    # set and checking whether the cache directory was populated.
+    def _init_cmd(self, env, binary):
+        return run_init(env, 'terragrunt version %s' % binary)[0][-1]
+
+    def test_tg_spelling_is_read_from_0_73_0(self):
+        self.assertEqual(self._init_cmd({'TG_PROVIDER_CACHE': '1'}, 'v0.73.0'), UNLOCKED)
+
+    def test_tg_spelling_is_ignored_on_0_72_0(self):
+        self.assertEqual(self._init_cmd({'TG_PROVIDER_CACHE': '1'}, 'v0.72.0'), LOCKED)
+
+    def test_legacy_spelling_is_read_from_0_56_4(self):
+        self.assertEqual(self._init_cmd({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v0.56.4'), UNLOCKED)
+
+    def test_legacy_spelling_is_ignored_on_0_56_3(self):
+        self.assertEqual(self._init_cmd({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v0.56.3'), LOCKED)
+
+    def test_legacy_spelling_carries_a_0_72_user(self):
+        # The window where only the legacy name exists.
+        self.assertEqual(self._init_cmd({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v0.72.0'), UNLOCKED)
+
+    def test_legacy_spelling_is_still_honoured_on_1_1_4(self):
+        self.assertEqual(self._init_cmd({'TERRAGRUNT_PROVIDER_CACHE': '1'}, 'v1.1.4'), UNLOCKED)
+
+
+class PrecedenceTest(unittest.TestCase):
+    # Verified against 0.77.9 and 1.1.4: a TG_ value that is present wins over
+    # the legacy name, even when it is false; an empty TG_ falls through.
+    def _init_cmd(self, env, binary='v0.77.9'):
+        return run_init(env, 'terragrunt version %s' % binary)[0][-1]
+
+    def test_a_false_tg_value_beats_a_true_legacy_one(self):
+        self.assertEqual(
+            self._init_cmd({'TG_PROVIDER_CACHE': 'false', 'TERRAGRUNT_PROVIDER_CACHE': 'true'}),
+            LOCKED)
+
+    def test_but_not_on_a_version_that_does_not_read_tg(self):
+        self.assertEqual(
+            self._init_cmd({'TG_PROVIDER_CACHE': 'false', 'TERRAGRUNT_PROVIDER_CACHE': 'true'},
+                           'v0.72.0'),
+            UNLOCKED)
+
+    def test_an_empty_tg_value_falls_through_to_legacy(self):
+        self.assertEqual(
+            self._init_cmd({'TG_PROVIDER_CACHE': '', 'TERRAGRUNT_PROVIDER_CACHE': '1'}),
+            UNLOCKED)
+
+
+class TheBinaryDecidesTest(unittest.TestCase):
+    def test_the_configured_version_is_not_trusted(self):
+        # engine.version only sets a tenv default. A version file in the
+        # repository can pick an older binary, and that older binary ignores
+        # the flag, so the decision is made from what actually runs.
+        (calls, warn, _) = run_init(OPTED_IN, 'terragrunt version v0.50.0', version='0.77.9')
+        self.assertEqual(calls[-1], LOCKED)
+        self.assertIn('0.50.0', ' '.join(str(a) for a in warn.call_args[0]))
+
+    def test_latest_is_not_a_guess_here(self):
+        # For workspace_cmd, 'latest' may be assumed new; for the lock it may
+        # not, and there is no need: the probe says what 'latest' resolved to.
+        (calls, _, _) = run_init(OPTED_IN, 'terragrunt version v0.50.0', version='latest')
+        self.assertEqual(calls[-1], LOCKED)
+
+    def test_a_failed_probe_keeps_the_lock(self):
+        (calls, warn, _) = run_init(OPTED_IN, rc=1)
+        self.assertEqual(calls[-1], LOCKED)
+        self.assertIn('could not be determined', ' '.join(str(a) for a in warn.call_args[0]))
+
+    def test_a_failed_probe_is_not_remembered(self):
+        # init has its own three tries at installing the toolchain. If one of
+        # those succeeds, workspace_cmd must look again rather than run the
+        # legacy command against a Terragrunt that no longer accepts it.
+        (_, _, engine) = run_init(OPTED_IN, rc=1)
+        toolchain = Toolchain('terragrunt version v0.88.0')
+
+        with mock.patch('engine_tf.cmd.run_with_output', side_effect=toolchain):
+            cmd = engine.workspace_cmd(state(OPTED_IN), 'select', 'default')
+
+        self.assertEqual(toolchain.calls, [PROBE_TG])
+        self.assertEqual(cmd, ['terragrunt', 'run', '--', 'workspace', 'select', 'default'])
+
+    def test_the_detected_version_is_reused_by_workspace_cmd(self):
+        (_, _, engine) = run_init(OPTED_IN, 'terragrunt version v0.88.0')
+        toolchain = Toolchain()
+
+        with mock.patch('engine_tf.cmd.run_with_output', side_effect=toolchain):
+            cmd = engine.workspace_cmd(state(OPTED_IN), 'select', 'default')
+
+        self.assertEqual(toolchain.calls, [])
+        self.assertEqual(cmd, ['terragrunt', 'run', '--', 'workspace', 'select', 'default'])
+
+    def test_the_veto_names_the_detected_version(self):
+        (_, warn, _) = run_init(OPTED_IN, 'terragrunt version v0.72.0', version='latest')
         self.assertEqual(warn.call_count, 1)
+        self.assertIn('0.72.0', ' '.join(str(a) for a in warn.call_args[0]))
+
+
+class WorkspaceCommandTest(unittest.TestCase):
+    # Pre-existing behaviour on the default path, untouched.
+    def _cmd(self, version, binary=None):
+        toolchain = Toolchain(binary or 'terragrunt version v0.77.9')
+        engine = engine_terragrunt.make(version=version)
+
+        with mock.patch('engine_tf.cmd.run_with_output', side_effect=toolchain):
+            return (engine.workspace_cmd(state({}, version), 'select', 'x'), toolchain.calls)
+
+    def test_a_parseable_configured_version_needs_no_probe(self):
+        (cmd, calls) = self._cmd('0.88.0')
+        self.assertEqual(cmd, ['terragrunt', 'run', '--', 'workspace', 'select', 'x'])
+        self.assertEqual(calls, [])
+
+    def test_an_unparseable_version_probes_under_the_lock(self):
+        (cmd, calls) = self._cmd('latest', 'terragrunt version v0.77.9')
+        self.assertEqual(cmd, ['terragrunt', 'workspace', 'select', 'x'])
+        self.assertEqual(calls, [PROBE_TG])
 
 
 class PickleTest(unittest.TestCase):
-    # Every dirspace gets its engine by pickling the run state into a
-    # multiprocessing worker, so cached state has to survive the round trip.
-    def test_an_engine_survives_a_round_trip_before_resolving(self):
+    def test_the_engine_is_picklable(self):
         engine = pickle.loads(pickle.dumps(engine_terragrunt.make(version='0.77.9')))
-        self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9')))
-
-    def test_an_engine_survives_a_round_trip_after_resolving(self):
-        engine = engine_terragrunt.make(version='0.77.9')
-        engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9'))
-        engine = pickle.loads(pickle.dumps(engine))
-        self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'}, '0.77.9')))
-
-    def test_workspace_selection_survives_a_round_trip(self):
-        engine = pickle.loads(pickle.dumps(engine_terragrunt.make(version='0.77.9')))
-        self.assertEqual(
-            engine.workspace_cmd(state(version='0.77.9'), 'select', 'default'),
-            ['terragrunt', 'workspace', 'select', 'default'])
-
-
-class InitCommandTest(unittest.TestCase):
-    def _calls(self, version, env):
-        engine = engine_terragrunt.make(version=version)
-
-        with mock.patch('engine_tf.cmd.run_with_output') as run:
-            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
-            with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
-                            return_value=False):
-                engine.init(state(env, version), {})
-
-        return [c[0][1]['cmd'] for c in run.call_args_list]
-
-    def test_default_is_unchanged_from_before(self):
-        self.assertEqual(
-            self._calls('0.77.9', {}),
-            [['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
-
-    def test_opting_in_unlocks_init_but_not_the_install(self):
-        self.assertEqual(
-            self._calls('0.77.9', {'TG_PROVIDER_CACHE': '1'}),
-            [['flock', engine_tf.INIT_LOCK, 'terragrunt', '--version'],
-             ['terragrunt', 'init']])
-
-    def test_an_old_version_keeps_the_lock_and_adds_nothing(self):
-        self.assertEqual(
-            self._calls('0.50.0', {'TG_PROVIDER_CACHE': '1'}),
-            [['flock', engine_tf.INIT_LOCK, 'terragrunt', 'init']])
-
-
-class VersionProbeRaceTest(unittest.TestCase):
-    # _detect_installed_version shells out to `<tf_cmd> --version`, which under
-    # TENV_AUTO_INSTALL is itself an install. It runs before init has taken any
-    # lock, so it has to take one itself.
-    def test_version_detection_is_serialised(self):
-        engine = engine_terragrunt.make()
-        captured = {}
-
-        def fake_run(cmd, **kwargs):
-            captured['cmd'] = cmd
-            return SimpleNamespace(returncode=0, stdout='terragrunt version v0.77.9', stderr='')
-
-        with mock.patch('engine_terragrunt.subprocess.run', side_effect=fake_run):
-            engine._detect_installed_version(state())
-
-        self.assertEqual(captured['cmd'][:2], ['flock', engine_tf.INIT_LOCK])
-        self.assertEqual(captured['cmd'][-1], '--version')
-
-    def test_an_unpinned_opted_in_engine_still_resolves(self):
-        engine = engine_terragrunt.make()
-
-        with mock.patch('engine_terragrunt.subprocess.run') as run:
-            run.return_value = SimpleNamespace(
-                returncode=0, stdout='terragrunt version v0.77.9', stderr='')
-            self.assertFalse(engine.lock_init(state({'TG_PROVIDER_CACHE': '1'})))
+        self.assertEqual(engine.tf_cmd, 'terragrunt')
 
 
 if __name__ == '__main__':

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -274,6 +274,26 @@ class ProbeToolchainTest(unittest.TestCase):
         self.assertEqual(warn.call_count, 0)
         self.assertEqual(result, (0, 'OpenTofu v1.6.3', ''))
 
+    def test_an_install_is_reported_at_info(self):
+        # tenv says nothing when the binary is already there, so this line
+        # appears only on the dirspace that actually installed it.
+        engine = engine_tf.make(override_tf_cmd='terraform')
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'OpenTofu v1.8.1',
+                                'Resolved version from TOFUENV_TOFU_DEFAULT_VERSION : 1.8.1\nInstalling OpenTofu 1.8.1\n')
+            with mock.patch('engine_tf.logging.info') as info:
+                engine.probe_toolchain(_state(), 'tofu')
+        self.assertEqual(info.call_count, 1)
+        self.assertIn('Installing OpenTofu 1.8.1', ' '.join(str(a) for a in info.call_args[0]))
+
+    def test_an_already_installed_binary_is_silent(self):
+        engine = engine_tf.make(override_tf_cmd='terraform')
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'OpenTofu v1.8.1', '')
+            with mock.patch('engine_tf.logging.info') as info:
+                engine.probe_toolchain(_state(), 'tofu')
+        self.assertEqual(info.call_count, 0)
+
     def test_a_failed_probe_warns_with_the_reason(self):
         # log_output is False, so this is otherwise invisible and the operator
         # only sees the init failure that follows, which looks unrelated.

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -287,12 +287,15 @@ class ProbeToolchainTest(unittest.TestCase):
         self.assertIn('Installing OpenTofu 1.8.1', ' '.join(str(a) for a in info.call_args[0]))
 
     def test_an_already_installed_binary_is_silent(self):
-        engine = engine_tf.make(override_tf_cmd='terraform')
-        with mock.patch('engine_tf.cmd.run_with_output') as run:
-            run.return_value = (SimpleNamespace(returncode=0), 'OpenTofu v1.8.1', '')
-            with mock.patch('engine_tf.logging.info') as info:
-                engine.probe_toolchain(_state(), 'tofu')
-        self.assertEqual(info.call_count, 0)
+        # Including when the tool itself grumbles on stderr, as Terragrunt does
+        # about TF_INPUT: that is not an install and must not look like one.
+        for stderr in ('', 'WARN   The `TF_INPUT` environment variable is deprecated'):
+            engine = engine_tf.make(override_tf_cmd='terraform')
+            with mock.patch('engine_tf.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'OpenTofu v1.8.1', stderr)
+                with mock.patch('engine_tf.logging.info') as info:
+                    engine.probe_toolchain(_state(), 'tofu')
+            self.assertEqual(info.call_count, 0, stderr)
 
     def test_a_failed_probe_warns_with_the_reason(self):
         # log_output is False, so this is otherwise invisible and the operator

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -191,5 +191,53 @@ class ApplyTest(unittest.TestCase):
             ['terraform', 'apply', '-auto-approve', '-target=module.foo'])
 
 
+class InitTest(unittest.TestCase):
+    def _calls(self, engine, config=None):
+        state = SimpleNamespace(
+            path='.',
+            env={},
+            working_dir='/nonexistent',
+            workflow={'engine': {'name': 'terraform'}},
+            repo_config={}
+        )
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+            with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
+                            return_value=False):
+                engine.init(state, config or {})
+
+        return [c[0][1]['cmd'] for c in run.call_args_list]
+
+    def test_the_toolchain_install_is_serialised(self):
+        # terrateam#393: concurrent tenv installs could leave a dirspace with no
+        # binary. This runs before init and is a no-op once installed.
+        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'))
+        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
+
+    def test_terraform_init_is_locked_by_default(self):
+        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'))
+        self.assertEqual(calls[1], ['flock', engine_tf.INIT_LOCK, 'terraform', 'init'])
+
+    def test_an_engine_may_unlock_init(self):
+        engine = engine_tf.make(override_tf_cmd='terraform')
+        engine.lock_init = lambda state: False
+        calls = self._calls(engine)
+        # The toolchain install stays serialised either way.
+        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
+        self.assertEqual(calls[1], ['terraform', 'init'])
+
+    def test_extra_args_reach_init_only(self):
+        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'),
+                            {'extra_args': ['-upgrade']})
+        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
+        self.assertEqual(calls[1],
+                         ['flock', engine_tf.INIT_LOCK, 'terraform', 'init', '-upgrade'])
+
+    def test_tofu_installs_its_own_toolchain(self):
+        calls = self._calls(engine_tf.make(override_tf_cmd='tofu'))
+        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -234,6 +234,33 @@ class InitTest(unittest.TestCase):
         self.assertEqual(calls[1],
                          ['flock', engine_tf.INIT_LOCK, 'terraform', 'init', '-upgrade'])
 
+    def test_a_failed_toolchain_install_is_reported(self):
+        # log_output is False, so a failure here is otherwise invisible and the
+        # operator only sees a confusing init failure afterwards.
+        state = SimpleNamespace(path='dir/space', env={}, working_dir='/nonexistent',
+                                workflow={'engine': {'name': 'terraform'}}, repo_config={})
+        engine = engine_tf.make(override_tf_cmd='terraform')
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=1), 'out', 'boom')
+            with mock.patch('engine_tf.logging.warning') as warn:
+                engine.install_toolchain(state)
+
+        self.assertEqual(warn.call_count, 1)
+        self.assertIn('boom', ' '.join(str(a) for a in warn.call_args[0]))
+
+    def test_a_successful_toolchain_install_is_quiet(self):
+        state = SimpleNamespace(path='dir/space', env={}, working_dir='/nonexistent',
+                                workflow={'engine': {'name': 'terraform'}}, repo_config={})
+        engine = engine_tf.make(override_tf_cmd='terraform')
+
+        with mock.patch('engine_tf.cmd.run_with_output') as run:
+            run.return_value = (SimpleNamespace(returncode=0), 'out', '')
+            with mock.patch('engine_tf.logging.warning') as warn:
+                engine.install_toolchain(state)
+
+        self.assertEqual(warn.call_count, 0)
+
     def test_tofu_installs_its_own_toolchain(self):
         calls = self._calls(engine_tf.make(override_tf_cmd='tofu'))
         self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -209,30 +209,43 @@ class InitTest(unittest.TestCase):
 
         return [c[0][1]['cmd'] for c in run.call_args_list]
 
-    def test_the_toolchain_install_is_serialised(self):
-        # terrateam#393: concurrent tenv installs could leave a dirspace with no
-        # binary. This runs before init and is a no-op once installed.
-        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'))
-        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
-
-    def test_terraform_init_is_locked_by_default(self):
-        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'))
-        self.assertEqual(calls[1], ['flock', engine_tf.INIT_LOCK, 'terraform', 'init'])
-
-    def test_an_engine_may_unlock_init(self):
-        engine = engine_tf.make(override_tf_cmd='terraform')
+    def _unlocked(self, tf_cmd='terraform'):
+        engine = engine_tf.make(override_tf_cmd=tf_cmd)
         engine.lock_init = lambda state: False
-        calls = self._calls(engine)
-        # The toolchain install stays serialised either way.
-        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
-        self.assertEqual(calls[1], ['terraform', 'init'])
+        return engine
 
-    def test_extra_args_reach_init_only(self):
-        calls = self._calls(engine_tf.make(override_tf_cmd='terraform'),
-                            {'extra_args': ['-upgrade']})
-        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'terraform', '--version'])
-        self.assertEqual(calls[1],
-                         ['flock', engine_tf.INIT_LOCK, 'terraform', 'init', '-upgrade'])
+    def test_the_default_path_is_byte_identical_to_before(self):
+        # A locked init already serialises the tenv install, which is the whole
+        # of terrateam#393, so nothing is added for anyone who changes nothing.
+        # This is the blast radius of the change: none.
+        self.assertEqual(
+            self._calls(engine_tf.make(override_tf_cmd='terraform')),
+            [['flock', engine_tf.INIT_LOCK, 'terraform', 'init']])
+
+    def test_the_default_path_adds_no_extra_subprocess(self):
+        self.assertEqual(len(self._calls(engine_tf.make(override_tf_cmd='terraform'))), 1)
+
+    def test_unlocking_init_adds_the_serialised_install(self):
+        # Without the lock on init, nothing else serialises the tenv install.
+        self.assertEqual(
+            self._calls(self._unlocked()),
+            [['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
+             ['terraform', 'init']])
+
+    def test_extra_args_reach_init_and_not_the_probe(self):
+        self.assertEqual(
+            self._calls(self._unlocked(), {'extra_args': ['-upgrade']}),
+            [['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
+             ['terraform', 'init', '-upgrade']])
+
+    def test_extra_args_on_the_locked_path(self):
+        self.assertEqual(
+            self._calls(engine_tf.make(override_tf_cmd='terraform'), {'extra_args': ['-upgrade']}),
+            [['flock', engine_tf.INIT_LOCK, 'terraform', 'init', '-upgrade']])
+
+    def test_tofu_probes_its_own_toolchain(self):
+        self.assertEqual(self._calls(self._unlocked('tofu'))[0],
+                         ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])
 
     def test_a_failed_toolchain_install_is_reported(self):
         # log_output is False, so a failure here is otherwise invisible and the
@@ -260,10 +273,6 @@ class InitTest(unittest.TestCase):
                 engine.install_toolchain(state)
 
         self.assertEqual(warn.call_count, 0)
-
-    def test_tofu_installs_its_own_toolchain(self):
-        calls = self._calls(engine_tf.make(override_tf_cmd='tofu'))
-        self.assertEqual(calls[0], ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])
 
 
 if __name__ == '__main__':

--- a/terrat_runner/test_engine_tf.py
+++ b/terrat_runner/test_engine_tf.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 from types import SimpleNamespace
 from unittest import mock
@@ -191,28 +192,32 @@ class ApplyTest(unittest.TestCase):
             ['terraform', 'apply', '-auto-approve', '-target=module.foo'])
 
 
+class Unlocked(engine_tf.Engine):
+    # The way a real engine opts out: by overriding the hook, not by poking an
+    # attribute. Keeps the engine picklable, which the run state requires.
+    def lock_init(self, state):
+        return False
+
+
+def _state():
+    return SimpleNamespace(
+        path='dir/space',
+        env={},
+        working_dir='/nonexistent',
+        workflow={'engine': {'name': 'terraform'}},
+        repo_config={}
+    )
+
+
 class InitTest(unittest.TestCase):
     def _calls(self, engine, config=None):
-        state = SimpleNamespace(
-            path='.',
-            env={},
-            working_dir='/nonexistent',
-            workflow={'engine': {'name': 'terraform'}},
-            repo_config={}
-        )
-
         with mock.patch('engine_tf.cmd.run_with_output') as run:
             run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
             with mock.patch('engine_tf.repo_config.get_create_and_select_workspace',
                             return_value=False):
-                engine.init(state, config or {})
+                engine.init(_state(), config or {})
 
         return [c[0][1]['cmd'] for c in run.call_args_list]
-
-    def _unlocked(self, tf_cmd='terraform'):
-        engine = engine_tf.make(override_tf_cmd=tf_cmd)
-        engine.lock_init = lambda state: False
-        return engine
 
     def test_the_default_path_is_byte_identical_to_before(self):
         # A locked init already serialises the tenv install, which is the whole
@@ -222,57 +227,69 @@ class InitTest(unittest.TestCase):
             self._calls(engine_tf.make(override_tf_cmd='terraform')),
             [['flock', engine_tf.INIT_LOCK, 'terraform', 'init']])
 
-    def test_the_default_path_adds_no_extra_subprocess(self):
-        self.assertEqual(len(self._calls(engine_tf.make(override_tf_cmd='terraform'))), 1)
-
-    def test_unlocking_init_adds_the_serialised_install(self):
-        # Without the lock on init, nothing else serialises the tenv install.
+    def test_tofu_is_the_same(self):
         self.assertEqual(
-            self._calls(self._unlocked()),
-            [['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
-             ['terraform', 'init']])
+            self._calls(engine_tf.make(override_tf_cmd='tofu')),
+            [['flock', engine_tf.INIT_LOCK, 'tofu', 'init']])
 
-    def test_extra_args_reach_init_and_not_the_probe(self):
+    def test_an_engine_that_unlocks_gets_a_bare_init(self):
+        # And nothing else: the contract puts the toolchain install on the
+        # engine that chose to unlock, not on this base class.
         self.assertEqual(
-            self._calls(self._unlocked(), {'extra_args': ['-upgrade']}),
-            [['flock', engine_tf.INIT_LOCK, 'terraform', '--version'],
-             ['terraform', 'init', '-upgrade']])
+            self._calls(Unlocked('tf', 'terraform')),
+            [['terraform', 'init']])
 
     def test_extra_args_on_the_locked_path(self):
         self.assertEqual(
             self._calls(engine_tf.make(override_tf_cmd='terraform'), {'extra_args': ['-upgrade']}),
             [['flock', engine_tf.INIT_LOCK, 'terraform', 'init', '-upgrade']])
 
-    def test_tofu_probes_its_own_toolchain(self):
-        self.assertEqual(self._calls(self._unlocked('tofu'))[0],
-                         ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])
+    def test_extra_args_on_the_unlocked_path(self):
+        self.assertEqual(
+            self._calls(Unlocked('tf', 'terraform'), {'extra_args': ['-upgrade']}),
+            [['terraform', 'init', '-upgrade']])
 
-    def test_a_failed_toolchain_install_is_reported(self):
-        # log_output is False, so a failure here is otherwise invisible and the
-        # operator only sees a confusing init failure afterwards.
-        state = SimpleNamespace(path='dir/space', env={}, working_dir='/nonexistent',
-                                workflow={'engine': {'name': 'terraform'}}, repo_config={})
+
+class ProbeToolchainTest(unittest.TestCase):
+    def _probe(self, tf_cmd, returncode, stdout='', stderr=''):
         engine = engine_tf.make(override_tf_cmd='terraform')
 
         with mock.patch('engine_tf.cmd.run_with_output') as run:
-            run.return_value = (SimpleNamespace(returncode=1), 'out', 'boom')
+            run.return_value = (SimpleNamespace(returncode=returncode), stdout, stderr)
             with mock.patch('engine_tf.logging.warning') as warn:
-                engine.install_toolchain(state)
+                result = engine.probe_toolchain(_state(), tf_cmd)
 
-        self.assertEqual(warn.call_count, 1)
-        self.assertIn('boom', ' '.join(str(a) for a in warn.call_args[0]))
+        return (run.call_args[0][1], warn, result)
 
-    def test_a_successful_toolchain_install_is_quiet(self):
-        state = SimpleNamespace(path='dir/space', env={}, working_dir='/nonexistent',
-                                workflow={'engine': {'name': 'terraform'}}, repo_config={})
-        engine = engine_tf.make(override_tf_cmd='terraform')
+    def test_the_probe_takes_the_init_lock(self):
+        (config, _, _) = self._probe('tofu', 0)
+        self.assertEqual(config['cmd'], ['flock', engine_tf.INIT_LOCK, 'tofu', '--version'])
 
-        with mock.patch('engine_tf.cmd.run_with_output') as run:
-            run.return_value = (SimpleNamespace(returncode=0), 'out', '')
-            with mock.patch('engine_tf.logging.warning') as warn:
-                engine.install_toolchain(state)
+    def test_the_probe_is_quiet_in_the_job_log(self):
+        (config, _, _) = self._probe('tofu', 0)
+        self.assertFalse(config['log_output'])
 
+    def test_a_successful_probe_does_not_warn(self):
+        (_, warn, result) = self._probe('tofu', 0, 'OpenTofu v1.6.3')
         self.assertEqual(warn.call_count, 0)
+        self.assertEqual(result, (0, 'OpenTofu v1.6.3', ''))
+
+    def test_a_failed_probe_warns_with_the_reason(self):
+        # log_output is False, so this is otherwise invisible and the operator
+        # only sees the init failure that follows, which looks unrelated.
+        (_, warn, result) = self._probe('tofu', 42, '', 'no such version')
+        self.assertEqual(warn.call_count, 1)
+        self.assertIn('no such version', ' '.join(str(a) for a in warn.call_args[0]))
+        self.assertEqual(result[0], 42)
+
+
+class PickleTest(unittest.TestCase):
+    # The run state, engine included, is pickled into a multiprocessing.Pool
+    # for every dirspace, so an engine that cannot be pickled breaks the run
+    # before init is reached.
+    def test_engines_are_picklable(self):
+        for engine in (engine_tf.make(override_tf_cmd='terraform'), Unlocked('tf', 'terraform')):
+            self.assertEqual(pickle.loads(pickle.dumps(engine)).tf_cmd, 'terraform')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #668

## TL;DR for reviewers

**The problem.** When Terrateam plans several directories at once, each one runs `init`, and we wrap every `init` in a lock so only one runs at a time. The lock was added because the tool that installs Terraform/OpenTofu/Terragrunt on first use (`tenv`) isn't safe to run concurrently — two dirspaces installing at once could leave one with no binary. But the install only happens once per run, while the lock makes *everything* in `init` wait: downloading modules, cloning sources, setting up the backend. On a Terragrunt repo with ten directories that turns a few seconds of real contention into minutes of waiting in line.

**The change.** Terragrunt has a built-in "provider cache server" that makes concurrent `init` safe by design (it takes its own cross-process lock; I confirmed this in Terragrunt's source, not by assumption). When an operator turns that on, we now skip our lock for `init` — but only after we've done, under the lock, the one thing the lock was actually for: install the toolchain. We check the Terragrunt binary really will honour the setting by asking it for its version, because a configured version and the version that actually runs can differ.

**What does not change.** If you don't set `TG_PROVIDER_CACHE`, nothing is different. Not one extra command, not one extra log line. That's the blast radius for every existing user, and it's the first thing to verify: `test_the_default_path_is_byte_identical_to_before`, and the end-to-end row "default path" below (16 dirspaces, every init command identical to production).

**Why it's opt-in.** Providers fetched through Terragrunt's cache server install as `(unauthenticated)` — their signatures aren't checked against the registry on first install (their hashes still are, on every later init). That's a security-posture decision the operator should make, not inherit.

**Where to look.**
- `engine_tf.py` — `lock_init()` returns `True` by default; `probe_toolchain()` is the serialised install. ~40 lines.
- `engine_terragrunt.py` — the override. Reads the two possible env-var spellings the way Terragrunt does (verified on every release 0.50.0 → 1.1.4), probes both binaries under the lock, decides from the probed version. Keeps the lock on anything it isn't certain about.
- The three test files. Every test is mocked; none reaches a real subprocess or the real lock file.

**How this was tested.** By hand — CI doesn't run the Python suite. 101 unit tests plus end-to-end runs against a demo repo with the branch published as a container image, including the shape a previous review found broken (terragrunt-only, six directories, a tofu version not in the image). Details in "Tests".

**What to be sceptical of.** cdktf inherits this and was only tested by unit test, not end to end. The speed-up is modelled from a real run log, not measured on a repo that size yet.

---

## What

`init` keeps its lock. What changes is that an engine can now say the lock is unnecessary, and one engine does, under conditions it verifies itself.

| | before init | init |
|---|---|---|
| any engine, nothing set | — | `flock /tmp/tf-init.lock <cmd> init` — identical to `main` |
| Terragrunt, `TG_PROVIDER_CACHE` set, binary honours it | `flock … <tf> --version` then `flock … terragrunt --version` | `terragrunt init` |
| Terragrunt, `TG_PROVIDER_CACHE` set, binary does not | same two probes | locked, with a `WARN` naming the detected version |

A new `lock_init(state)` hook returns `True` in `engine_tf`. `engine_terragrunt` overrides it. **Anyone who does not opt in issues exactly the same commands as before** — no probe, no extra subprocess, nothing in the log.

## Why

dc31a46 added the lock for `tenv`: with `TENV_AUTO_INSTALL=true` the pinned binary is installed on first use, and concurrent installs could leave a dirspace with no binary at all. That install happens once per run, but the lock wraps the whole `init`, so every dirspace also serialises its source fetch, backend init, module downloads and provider install behind every other dirspace. On a Terragrunt repository that is most of `init`, and none of it contends.

Terragrunt's provider cache server removes the reason for the lock. It downloads each provider once and serves every unit from a local registry, and it does so **under a `flock` on a lock file shared by every Terragrunt process on the machine** (`tf/cache/services/provider_cache.go`, `startProviderCaching`: "We need to use a locking mechanism between Terragrunt processes to prevent simultaneous write access to the same provider"; the lock file lives in `os.TempDir()/terragrunt/providers/`, and the runner does not set a per-dirspace `TMPDIR`). The existence check happens inside that lock, so a second process waits for the first's unpack to finish and then finds the package. That is precisely the guarantee Terraform's own plugin cache lacks (hashicorp/terraform#31964, open since 2022), which is why this is the one case where unlocking is defensible.

It is opt-in because providers served that way install as `(unauthenticated)` — the hashes still go into `.terraform.lock.hcl` and are verified on every later init, so integrity holds, but the signature is not checked against the origin registry on first install. That is the operator's call.

## What the unlocked path has to get right

Unlocking hands the engine both of the lock's jobs, and each one was found wrong in review.

**The toolchain install.** Terragrunt shells out to a tofu or terraform that tenv also installs on first use, and `TOFU_DEFAULT_VERSION` (1.9.0) is not among the versions baked into the image, so a terragrunt-only repository with default settings installs it on every run. Probing only `terragrunt --version` left that install racing across dirspaces — #393 again, one layer down. Both binaries are now probed under the lock, the underlying one first, before the decision is made.

**Whether the cache server will actually run.** The decision is made from the version the probe reports, never from configuration: `engine.version` only sets a tenv default, and a version file in the repository can quietly pick an older binary that ignores the flag. What counts as a request matches Terragrunt exactly, established by running every release from 0.50.0 to 1.1.4 with each setting and checking whether the cache directory was populated:

| | read from | verified through | newer than that |
|---|---|---|---|
| `TG_PROVIDER_CACHE` | 0.73.0 | 1.1.4 (newest release) | trusted — it is the current name |
| `TERRAGRUNT_PROVIDER_CACHE` | 0.56.4 | 1.1.4, with a deprecation warning since 0.73.0 | **keeps the lock** — it has warned of removal, and the day it goes a legacy-only request would unlock with no cache server; the `WARN` names `TG_PROVIDER_CACHE` as the fix |

On a version that reads `TG_PROVIDER_CACHE`, a present value wins over the legacy name even when it is `false`; an empty one falls through. Values are Go's `strconv.ParseBool` — `1`, `t`, `T`, `true`, `True`, `TRUE`. `yes` and `on` make Terragrunt exit with `invalid value`, so they are not treated as a request and the run takes the default path, where init reports that error itself.

A probe that fails keeps the lock and is not cached, so `workspace_cmd` looks again after init has had its own tries at the install. A probe that succeeds seeds the version `workspace_cmd` uses, so nothing is probed twice.

## Tests

101 pass, 40 new, across `engine_tf`, `engine_terragrunt` and `engine_cdktf` (whose `init` delegates into `engine_tf` and so inherits this). No test reaches a real subprocess; the hook is exercised by subclassing, as `engine_terragrunt` does.

**CI does not run this suite** — `ci.yaml` only builds the image on pushes to `v1`. Everything here was run by hand.

### End to end

Against `terrateam-demo/infrastructure`, with the branch built and published as a container image so the harness matches production. A paired BASE/HEAD run on production `:v1` and this branch produced identical init commands and identical plan output.

| case | result |
|---|---|
| default path — 16 dirspaces across `tofu`, `terraform`, `terragrunt`, `custom`, `parallel_runs 3` | 16/16, **0** probes, **0** log lines, every init command identical to `:v1` |
| `oidc` → `init` ordering | `oidc` → `init` → `plan`, credentials intact |
| `extra_args`; custom engine | reach `init` only; custom engine untouched |
| opted in, mixed repo | 16/16; probes only on the 3 terragrunt dirspaces; `terragrunt init` unlocked |
| **terragrunt-only, 6 units, `parallel_runs 6`, tofu 1.8.1 not baked** — the shape review finding 1 was about | 3 consecutive runs, 6/6 each, `terragrunt init` unlocked; **exactly one unit** reports `Installing OpenTofu 1.8.1` and `Installing Terragrunt 0.75.3`, the other five find both in place; 0 race symptoms |
| opted in on Terragrunt 0.50.0 | `requested but Terragrunt 0.50.0 will not start the cache server with this setting, keeping the init lock`, init locked; the dirspaces then fail identically on production `:v1` (a pre-existing Terragrunt/OpenTofu incompatibility) |
| unresolvable toolchain version; broken backend | same operator-visible error as `:v1`; retries still 3 for failures, 1 for healthy dirspaces |

Not covered end to end: cdktf (its demo repo needs a self-hosted runner with no run history; the delegation is asserted by test) and pulumi/stategraph/fly (module-level `init`, no reference to `engine_tf`; `custom`, the same shape, was run as the representative).
