### PR TITLE
fix: drop pip cache from checkov install to shrink base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -67,7 +67,7 @@ RUN echo "AWSCLI_VERSION: ${AWSCLI_VERSION}" && \
 
 ENV CHECKOV_VERSION=2.5.10
 RUN python3 -m venv /opt/checkov && \
-    /opt/checkov/bin/pip install checkov==${CHECKOV_VERSION} && \
+    /opt/checkov/bin/pip install --no-cache-dir checkov==${CHECKOV_VERSION} && \
     ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov
 
 ENV RESOURCELY_VERSION=1.0.45


### PR DESCRIPTION
While digging into why our GitHub Actions runs using this action were slower than expected, I found that the checkov install step in Dockerfile.base leaves pip's download cache inside the image layer. It's about 80MB that's never touched again after the build finishes.

This has a real cost. The published image is already over 400MB, and every GitHub Actions run that uses this action pulls the whole thing before doing any actual work. That pull time counts against GitHub Actions minutes, so across all the repos and PRs using Terrateam, trimming unused weight from the image adds up to meaningful savings over time.

The fix is a single flag: pip install --no-cache-dir instead of pip install. This tells pip to skip writing its cache to disk during the install, so there's nothing extra left in the layer afterward.

I built the base image locally both before and after this change to measure the actual impact. The checkov layer went from 415MB to 333MB, an 82MB reduction. Checkov itself is unaffected, same version, same behavior, just without the cache files that were never needed at runtime.

## Test plan
- Built Dockerfile.base locally with and without the change
- Compared layer sizes with docker history, confirmed the 82MB reduction is isolated to the checkov layer
- Ran checkov --version in the built image to confirm it still installs and works correctly