### PR TITLE
stategraph/mono#1650 ADD Provider cache runner support

### DIFF
--- a/terrat_runner/provider_cache.py
+++ b/terrat_runner/provider_cache.py
@@ -1,0 +1,521 @@
+"""Terraform provider cache backed by the Terrateam KV store.
+
+The runner fills the cache; the server never talks to a registry.  Before the
+run, [setup] fetches the providers named by the lock files of the changed
+directories and points both engines at a filesystem mirror holding them.  After
+the run, [store] uploads whatever the engines had to download.
+
+The key ends with the provider's h1 hash, so a fetched package is only ever used
+when the repository's own lock file already records that exact package.  A
+provider whose lock file has no usable h1 is left alone and comes from the
+registry, as it does without this feature.
+"""
+
+import base64
+import binascii
+import glob
+import hashlib
+import io
+import logging
+import os
+import platform
+import re
+import shutil
+import urllib.parse
+import zipfile
+
+import repo_config as rc
+import requests_retry
+
+
+# Only public registries are cached.  A private registry host may serve a
+# provider that is not public, and one copy of it would save nothing anyway.
+CACHEABLE_HOSTS = frozenset(['registry.terraform.io', 'registry.opentofu.org'])
+
+CAPABILITY = 'provider_cache'
+KEY_PREFIX = 'provider-cache'
+
+# Raw bytes per KV row.  Base64 grows this by a third, so the JSON body stays
+# well under the server's 100 MB limit.
+CHUNK_SIZE = 8 * 1024 * 1024
+
+# kv_store.idx is a smallint.
+MAX_CHUNKS = 32767
+
+_PROVIDER_BLOCK_RE = re.compile(
+    r'provider\s+"(?P<source>[^"]+)"\s*\{(?P<body>.*?)\n\}',
+    re.DOTALL)
+_VERSION_RE = re.compile(r'\n\s*version\s*=\s*"(?P<version>[^"]+)"')
+_HASHES_RE = re.compile(r'\n\s*hashes\s*=\s*\[(?P<hashes>.*?)\]', re.DOTALL)
+_HASH_RE = re.compile(r'"(?P<hash>[^"]+)"')
+
+
+class Provider(object):
+    """One provider requirement read out of a .terraform.lock.hcl."""
+
+    def __init__(self, source, version, hashes):
+        self.source = source
+        self.version = version
+        self.hashes = hashes
+
+    @property
+    def host(self):
+        return self.source.split('/')[0]
+
+    def h1_hashes(self):
+        return [h for h in self.hashes if h.startswith('h1:')]
+
+    def mirror_path(self, mirror_dir, platform_name):
+        return os.path.join(mirror_dir, self.source, self.version, platform_name)
+
+    def __repr__(self):
+        return 'Provider({}, {})'.format(self.source, self.version)
+
+
+def platform_name():
+    machine = platform.machine().lower()
+    arch = {
+        'x86_64': 'amd64',
+        'amd64': 'amd64',
+        'aarch64': 'arm64',
+        'arm64': 'arm64',
+    }.get(machine, machine)
+
+    return '{}_{}'.format(platform.system().lower(), arch)
+
+
+def h1_of_dir(path):
+    """The engines' h1 hash: Go's dirhash.Hash1 over the package directory.
+
+    Each file contributes one "<sha256 hex>  <name>\\n" line, the lines are
+    sorted, and the hash is the base64 sha256 of that text.
+    """
+    names = []
+    for dirpath, _, filenames in os.walk(path):
+        for filename in filenames:
+            fname = os.path.join(dirpath, filename)
+            names.append((os.path.relpath(fname, path), fname))
+
+    summary = io.BytesIO()
+    for (name, fname) in sorted(names):
+        digest = hashlib.sha256()
+        with open(fname, 'rb') as f:
+            for block in iter(lambda: f.read(1024 * 1024), b''):
+                digest.update(block)
+
+        summary.write('{}  {}\n'.format(digest.hexdigest(), name).encode('utf-8'))
+
+    return 'h1:' + base64.b64encode(
+        hashlib.sha256(summary.getvalue()).digest()).decode('ascii')
+
+
+def h1_to_key_component(h1):
+    """Hex of the digest inside an h1 hash, or None if it is not one.
+
+    The lock file spells an h1 in base64, which carries '/' and '+' and cannot
+    go in a URL path unescaped.  Hex is the same 32 bytes and is URL safe.
+    """
+    if not h1.startswith('h1:'):
+        return None
+
+    try:
+        digest = base64.b64decode(h1[len('h1:'):], validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    if len(digest) != hashlib.sha256().digest_size:
+        return None
+
+    return digest.hex()
+
+
+def cache_key(provider, platform_name_, h1):
+    key_component = h1_to_key_component(h1)
+    if key_component is None:
+        return None
+
+    return '/'.join([KEY_PREFIX,
+                     provider.source,
+                     provider.version,
+                     platform_name_,
+                     key_component])
+
+
+def parse_lock_file(content):
+    """Read the providers out of the text of a .terraform.lock.hcl."""
+    providers = []
+    for block in _PROVIDER_BLOCK_RE.finditer(content):
+        body = block.group('body')
+        version = _VERSION_RE.search(body)
+        if version is None:
+            continue
+
+        hashes_match = _HASHES_RE.search(body)
+        hashes = ([h.group('hash') for h in _HASH_RE.finditer(hashes_match.group('hashes'))]
+                  if hashes_match is not None
+                  else [])
+
+        providers.append(Provider(block.group('source'), version.group('version'), hashes))
+
+    return providers
+
+
+def read_lock_files(working_dir, dirs):
+    """Every distinct provider named by the lock files of [dirs].
+
+    A directory with no lock file contributes nothing.  Without a lock file
+    both engines re-resolve the provider from the registry anyway, so there is
+    nothing the cache could serve.
+    """
+    providers = {}
+    for d in dirs:
+        path = os.path.join(working_dir, d, '.terraform.lock.hcl')
+        if not os.path.exists(path):
+            logging.debug('PROVIDER_CACHE : NO_LOCK_FILE : dir=%s', d)
+            continue
+
+        with open(path) as f:
+            content = f.read()
+
+        for provider in parse_lock_file(content):
+            existing = providers.get((provider.source, provider.version))
+            if existing is None:
+                providers[(provider.source, provider.version)] = provider
+            else:
+                # The same provider version can be locked in several
+                # directories with different hash sets.  Take the union so a
+                # hit in any of them counts.
+                for h in provider.hashes:
+                    if h not in existing.hashes:
+                        existing.hashes.append(h)
+
+    return list(providers.values())
+
+
+def cacheable(providers):
+    return [p for p in providers if p.host in CACHEABLE_HOSTS]
+
+
+def cli_config(mirror_dir, excluded_sources):
+    """The provider_installation block pointing the engines at the mirror.
+
+    Only the providers actually fetched are excluded from 'direct'.  Anything
+    else falls through to the registry, so a miss degrades to today's
+    behaviour rather than failing the run.
+    """
+    excludes = ', '.join('"{}"'.format(s) for s in sorted(excluded_sources))
+    return (
+        'provider_installation {\n'
+        '  filesystem_mirror {\n'
+        '    path = "' + mirror_dir + '"\n'
+        '  }\n'
+        '  direct {\n'
+        '    exclude = [' + excludes + ']\n'
+        '  }\n'
+        '}\n')
+
+
+def _headers(state):
+    return {'authorization': 'bearer ' + state.api_token}
+
+
+def _kv_base(state):
+    """The KV store URL for this installation.
+
+    [api_base_url] is <base>/api/<vcs>; the KV store is at
+    <base>/api/v1/<vcs>/kv/<installation_id>.
+    """
+    base, _, vcs = state.api_base_url.rpartition('/')
+    installation_id = state.work_manifest.get('installation_id')
+    if not base or not vcs or not installation_id:
+        return None
+
+    return '{}/v1/{}/kv/{}'.format(base, vcs, installation_id)
+
+
+def _key_url(kv_base, key):
+    return '{}/key/{}'.format(kv_base, urllib.parse.quote(key, safe='/'))
+
+
+def _get_chunk(state, kv_base, key, idx):
+    """The bytes of one chunk, or None if it is not there or does not verify."""
+    res = requests_retry.get(_key_url(kv_base, key),
+                             headers=_headers(state),
+                             params={'idx': idx})
+    if res.status_code != 200:
+        return None
+
+    payload = res.json().get('data')
+    if not isinstance(payload, dict):
+        return None
+
+    data = payload.get('data')
+    chk = payload.get('chk')
+    if not isinstance(data, str) or not isinstance(chk, str):
+        return None
+
+    if chk != 'sha256:' + hashlib.sha256(data.encode('utf-8')).hexdigest():
+        logging.warning('PROVIDER_CACHE : CHUNK_CHECKSUM_MISMATCH : key=%s : idx=%d', key, idx)
+        return None
+
+    try:
+        return base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _download(state, kv_base, key):
+    """Every chunk of [key] joined, or None if the first chunk is missing."""
+    chunks = []
+    for idx in range(MAX_CHUNKS + 1):
+        chunk = _get_chunk(state, kv_base, key, idx)
+        if chunk is None:
+            break
+
+        chunks.append(chunk)
+
+    if not chunks:
+        return None
+
+    return b''.join(chunks)
+
+
+def _put_chunk(state, kv_base, key, idx, chunk):
+    data = base64.b64encode(chunk).decode('ascii')
+    res = requests_retry.put(
+        _key_url(kv_base, key),
+        headers=_headers(state),
+        json={
+            'data': {
+                'chk': 'sha256:' + hashlib.sha256(data.encode('utf-8')).hexdigest(),
+                'data': data,
+            },
+            'idx': idx,
+            'committed': False,
+        })
+
+    return res.status_code == 200
+
+
+def _commit(state, kv_base, key):
+    res = requests_retry.post('{}/commit'.format(kv_base),
+                              headers=_headers(state),
+                              json={'keys': [{'key': key}]})
+    return res.status_code == 200
+
+
+def _unpack(blob, dst):
+    """Extract a provider zip into [dst].  False if it is not a usable zip."""
+    shutil.rmtree(dst, ignore_errors=True)
+    os.makedirs(dst, exist_ok=True)
+    try:
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            for name in zf.namelist():
+                # Refuse absolute paths and anything climbing out of [dst].
+                target = os.path.realpath(os.path.join(dst, name))
+                if not target.startswith(os.path.realpath(dst) + os.sep):
+                    logging.warning('PROVIDER_CACHE : UNSAFE_ZIP_ENTRY : %s', name)
+                    return False
+
+            for info in zf.infolist():
+                zf.extract(info, dst)
+                mode = info.external_attr >> 16
+                if mode:
+                    os.chmod(os.path.join(dst, info.filename), mode & 0o777)
+    except (zipfile.BadZipFile, OSError) as exn:
+        logging.warning('PROVIDER_CACHE : UNPACK_FAILED : %r', exn)
+        return False
+
+    return True
+
+
+def _zip_dir(path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for dirpath, _, filenames in os.walk(path):
+            for filename in sorted(filenames):
+                fname = os.path.join(dirpath, filename)
+                zf.write(fname, os.path.relpath(fname, path))
+
+    return buf.getvalue()
+
+
+def _fetch_provider(state, kv_base, provider, plat, mirror_dir):
+    """Put [provider] in the mirror.  True if it is there when we return.
+
+    Tries every h1 the lock file records.  The bytes are only kept when they
+    hash back to the h1 in the key, so a wrong or damaged object falls through
+    to the registry rather than failing the run.
+    """
+    dst = provider.mirror_path(mirror_dir, plat)
+    for h1 in provider.h1_hashes():
+        key = cache_key(provider, plat, h1)
+        if key is None:
+            continue
+
+        blob = _download(state, kv_base, key)
+        if blob is None:
+            continue
+
+        if not _unpack(blob, dst):
+            shutil.rmtree(dst, ignore_errors=True)
+            continue
+
+        actual = h1_of_dir(dst)
+        if actual != h1:
+            logging.warning('PROVIDER_CACHE : H1_MISMATCH : source=%s : version=%s : expected=%s : actual=%s',
+                            provider.source,
+                            provider.version,
+                            h1,
+                            actual)
+            shutil.rmtree(dst, ignore_errors=True)
+            continue
+
+        logging.info('PROVIDER_CACHE : HIT : source=%s : version=%s',
+                     provider.source,
+                     provider.version)
+        return True
+
+    logging.info('PROVIDER_CACHE : MISS : source=%s : version=%s',
+                 provider.source,
+                 provider.version)
+    return False
+
+
+def downloaded_packages(cache_dir):
+    """Every provider the engines downloaded into the plugin cache.
+
+    A package installed from the mirror is a symbolic link, so a real directory
+    is one that came from a registry and is not in the cache yet.
+    """
+    packages = []
+    for path in sorted(glob.glob(os.path.join(cache_dir, '*', '*', '*', '*', '*'))):
+        if not os.path.isdir(path) or os.path.islink(path):
+            continue
+
+        rest, plat = os.path.split(path)
+        rest, version = os.path.split(rest)
+        rest, type_ = os.path.split(rest)
+        rest, namespace = os.path.split(rest)
+        _, host = os.path.split(rest)
+        packages.append((path, '/'.join([host, namespace, type_]), version, plat))
+
+    return packages
+
+
+def _store_package(state, kv_base, path, source, version, plat):
+    h1 = h1_of_dir(path)
+    key = cache_key(Provider(source, version, [h1]), plat, h1)
+    if key is None:
+        return False
+
+    if _get_chunk(state, kv_base, key, 0) is not None:
+        logging.debug('PROVIDER_CACHE : ALREADY_STORED : source=%s : version=%s', source, version)
+        return False
+
+    blob = _zip_dir(path)
+    chunks = [blob[i:i + CHUNK_SIZE] for i in range(0, len(blob), CHUNK_SIZE)]
+    if not chunks or len(chunks) > MAX_CHUNKS:
+        logging.warning('PROVIDER_CACHE : UNSTORABLE_SIZE : source=%s : bytes=%d', source, len(blob))
+        return False
+
+    for idx, chunk in enumerate(chunks):
+        if not _put_chunk(state, kv_base, key, idx, chunk):
+            logging.warning('PROVIDER_CACHE : STORE_FAILED : source=%s : idx=%d', source, idx)
+            return False
+
+    if not _commit(state, kv_base, key):
+        logging.warning('PROVIDER_CACHE : COMMIT_FAILED : source=%s', source)
+        return False
+
+    logging.info('PROVIDER_CACHE : STORED : source=%s : version=%s : bytes=%d',
+                 source,
+                 version,
+                 len(blob))
+    return True
+
+
+def _conflicting_env(env):
+    """Variables the user already set that this feature would overwrite."""
+    return [k for k in ['TF_CLI_CONFIG_FILE', 'TF_PLUGIN_CACHE_DIR'] if env.get(k)]
+
+
+def enabled(state):
+    if CAPABILITY not in state.work_manifest.get('capabilities', []):
+        return False
+
+    if not rc.get_provider_cache(state.repo_config).get('enabled', False):
+        return False
+
+    conflicting = _conflicting_env(state.env)
+    if conflicting:
+        logging.info('PROVIDER_CACHE : DISABLED : env already set : %s', ','.join(conflicting))
+        return False
+
+    return True
+
+
+def setup(state):
+    """Fill the mirror and point the engines at it.  Returns the new state."""
+    if not enabled(state):
+        return state
+
+    kv_base = _kv_base(state)
+    if kv_base is None:
+        logging.warning('PROVIDER_CACHE : DISABLED : could not build the KV store URL')
+        return state
+
+    plat = platform_name()
+    mirror_dir = os.path.join(state.tmpdir, 'provider-mirror')
+    cache_dir = os.path.join(state.tmpdir, 'provider-cache')
+    os.makedirs(mirror_dir, exist_ok=True)
+    os.makedirs(cache_dir, exist_ok=True)
+
+    dirs = sorted({ds['path'] for ds in state.work_manifest.get('changed_dirspaces', [])})
+    providers = cacheable(read_lock_files(state.working_dir, dirs))
+
+    fetched = []
+    for provider in providers:
+        if _fetch_provider(state, kv_base, provider, plat, mirror_dir):
+            fetched.append(provider.source)
+
+    config_path = os.path.join(state.tmpdir, 'provider-cache.tfrc')
+    with open(config_path, 'w') as f:
+        f.write(cli_config(mirror_dir, set(fetched)))
+
+    logging.info('PROVIDER_CACHE : SETUP : providers=%d : fetched=%d',
+                 len(providers),
+                 len(fetched))
+
+    env = state.env.copy()
+    env['TF_CLI_CONFIG_FILE'] = config_path
+    env['TF_PLUGIN_CACHE_DIR'] = cache_dir
+    return state._replace(env=env)
+
+
+def store(state):
+    """Upload every provider the engines had to download during this run."""
+    if not enabled(state):
+        return
+
+    cache_dir = state.env.get('TF_PLUGIN_CACHE_DIR')
+    if not cache_dir:
+        return
+
+    kv_base = _kv_base(state)
+    if kv_base is None:
+        return
+
+    stored = 0
+    for (path, source, version, plat) in downloaded_packages(cache_dir):
+        if source.split('/')[0] not in CACHEABLE_HOSTS:
+            continue
+
+        try:
+            if _store_package(state, kv_base, path, source, version, plat):
+                stored += 1
+        except Exception:
+            # The cache must never fail a run that otherwise succeeded.
+            logging.exception('PROVIDER_CACHE : STORE_FAILED : source=%s', source)
+
+    logging.info('PROVIDER_CACHE : STORE : stored=%d', stored)

--- a/terrat_runner/repo_config.py
+++ b/terrat_runner/repo_config.py
@@ -229,3 +229,7 @@ def get_config_builder(config):
 
 def get_tree_builder(config):
     return _get(config, 'tree_builder', {'enabled': False})
+
+
+def get_provider_cache(config):
+    return _get(config, 'provider_cache', {'enabled': False})

--- a/terrat_runner/test_provider_cache.py
+++ b/terrat_runner/test_provider_cache.py
@@ -1,0 +1,299 @@
+import base64
+import hashlib
+import io
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+
+import provider_cache
+
+
+LOCK_FILE = '''# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = "3.2.2"
+  hashes = [
+    "h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+  ]
+}
+
+provider "terraform.example.com/acme/secret" {
+  version = "1.0.0"
+  hashes = [
+    "h1:awfs6PFJcbrz3PtasIlQyi6mUP2rN/BUSnK8mnTskf8=",
+  ]
+}
+'''
+
+
+def _write(path, name, content, mode=None):
+    fname = os.path.join(path, name)
+    os.makedirs(os.path.dirname(fname), exist_ok=True)
+    with open(fname, 'wb') as f:
+        f.write(content)
+
+    if mode is not None:
+        os.chmod(fname, mode)
+
+    return fname
+
+
+class LockFileTest(unittest.TestCase):
+    def test_parse_reads_source_version_and_hashes(self):
+        providers = provider_cache.parse_lock_file(LOCK_FILE)
+        self.assertEqual([p.source for p in providers],
+                         ['registry.opentofu.org/hashicorp/null',
+                          'terraform.example.com/acme/secret'])
+        self.assertEqual(providers[0].version, '3.2.2')
+        self.assertEqual(len(providers[0].hashes), 2)
+        self.assertEqual(providers[0].h1_hashes(),
+                         ['h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0='])
+
+    def test_parse_skips_a_block_without_a_version(self):
+        content = 'provider "registry.opentofu.org/hashicorp/null" {\n  hashes = []\n}\n'
+        self.assertEqual(provider_cache.parse_lock_file(content), [])
+
+    def test_parse_handles_a_block_without_hashes(self):
+        content = 'provider "registry.opentofu.org/hashicorp/null" {\n  version = "3.2.2"\n}\n'
+        providers = provider_cache.parse_lock_file(content)
+        self.assertEqual(len(providers), 1)
+        self.assertEqual(providers[0].hashes, [])
+        self.assertEqual(providers[0].h1_hashes(), [])
+
+    def test_only_public_registries_are_cacheable(self):
+        providers = provider_cache.parse_lock_file(LOCK_FILE)
+        self.assertEqual([p.source for p in provider_cache.cacheable(providers)],
+                         ['registry.opentofu.org/hashicorp/null'])
+
+    def test_read_lock_files_unions_hashes_across_directories(self):
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path, True)
+        one = 'provider "registry.opentofu.org/a/b" {\n  version = "1.0.0"\n  hashes = ["h1:one"]\n}\n'
+        two = 'provider "registry.opentofu.org/a/b" {\n  version = "1.0.0"\n  hashes = ["h1:two"]\n}\n'
+        _write(path, os.path.join('one', '.terraform.lock.hcl'), one.encode('utf-8'))
+        _write(path, os.path.join('two', '.terraform.lock.hcl'), two.encode('utf-8'))
+
+        providers = provider_cache.read_lock_files(path, ['one', 'two', 'no-lock-file'])
+
+        self.assertEqual(len(providers), 1)
+        self.assertEqual(sorted(providers[0].hashes), ['h1:one', 'h1:two'])
+
+
+class H1Test(unittest.TestCase):
+    """The h1 must be Go's dirhash.Hash1, which the engines compare against the
+    lock file.  The values below were cross-checked against the h1 that
+    Terraform 1.15.6 and OpenTofu 1.12.2 themselves wrote for hashicorp/null
+    3.2.2."""
+
+    def test_single_file_package(self):
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path, True)
+        _write(path, 'terraform-provider-null_v3.2.2_x5', b'hello')
+
+        digest = hashlib.sha256(b'hello').hexdigest()
+        summary = '{}  terraform-provider-null_v3.2.2_x5\n'.format(digest).encode('utf-8')
+        expected = 'h1:' + base64.b64encode(hashlib.sha256(summary).digest()).decode('ascii')
+
+        self.assertEqual(provider_cache.h1_of_dir(path), expected)
+
+    def test_files_are_ordered_by_name_not_by_hash(self):
+        # 'a' hashes above 'b', so a hash-ordered summary differs from the
+        # name-ordered one Hash1 specifies.  This is the defect that made the
+        # computed h1 miss the lock file for every multi-file package.
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path, True)
+        _write(path, 'a', b'a')
+        _write(path, 'b', b'b')
+
+        summary = ''.join(
+            '{}  {}\n'.format(hashlib.sha256(c).hexdigest(), n)
+            for (n, c) in [('a', b'a'), ('b', b'b')]).encode('utf-8')
+        expected = 'h1:' + base64.b64encode(hashlib.sha256(summary).digest()).decode('ascii')
+
+        self.assertEqual(provider_cache.h1_of_dir(path), expected)
+
+    def test_nested_files_use_their_relative_path(self):
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path, True)
+        _write(path, os.path.join('docs', 'README.md'), b'x')
+
+        summary = '{}  docs/README.md\n'.format(hashlib.sha256(b'x').hexdigest()).encode('utf-8')
+        expected = 'h1:' + base64.b64encode(hashlib.sha256(summary).digest()).decode('ascii')
+
+        self.assertEqual(provider_cache.h1_of_dir(path), expected)
+
+
+class KeyTest(unittest.TestCase):
+    def test_h1_becomes_hex_of_the_digest(self):
+        digest = bytes(range(32))
+        h1 = 'h1:' + base64.b64encode(digest).decode('ascii')
+        self.assertEqual(provider_cache.h1_to_key_component(h1), digest.hex())
+
+    def test_a_non_h1_hash_has_no_key_component(self):
+        self.assertIsNone(provider_cache.h1_to_key_component('zh:00e5877d19fb'))
+
+    def test_bad_base64_has_no_key_component(self):
+        self.assertIsNone(provider_cache.h1_to_key_component('h1:not base64!'))
+
+    def test_a_wrong_length_digest_has_no_key_component(self):
+        self.assertIsNone(
+            provider_cache.h1_to_key_component('h1:' + base64.b64encode(b'short').decode('ascii')))
+
+    def test_cache_key_shape(self):
+        digest = bytes(range(32))
+        h1 = 'h1:' + base64.b64encode(digest).decode('ascii')
+        provider = provider_cache.Provider('registry.opentofu.org/hashicorp/null', '3.2.2', [h1])
+
+        self.assertEqual(
+            provider_cache.cache_key(provider, 'linux_amd64', h1),
+            'provider-cache/registry.opentofu.org/hashicorp/null/3.2.2/linux_amd64/' + digest.hex())
+
+    def test_cache_key_is_none_when_the_hash_is_unusable(self):
+        provider = provider_cache.Provider('registry.opentofu.org/hashicorp/null', '3.2.2', [])
+        self.assertIsNone(provider_cache.cache_key(provider, 'linux_amd64', 'zh:abc'))
+
+    def test_the_key_has_no_url_unsafe_characters(self):
+        # A base64 h1 carries '/' and '+', which would break the URL path.
+        h1 = 'h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0='
+        component = provider_cache.h1_to_key_component(h1)
+        self.assertRegex(component, r'^[0-9a-f]{64}$')
+
+
+class CliConfigTest(unittest.TestCase):
+    def test_excludes_are_sorted_and_quoted(self):
+        config = provider_cache.cli_config('/m', {'registry.opentofu.org/b/c',
+                                                  'registry.terraform.io/a/b'})
+        self.assertIn('path = "/m"', config)
+        self.assertIn('exclude = ["registry.opentofu.org/b/c", "registry.terraform.io/a/b"]',
+                      config)
+
+    def test_no_hits_means_an_empty_exclude_list(self):
+        # Every provider then falls through to 'direct', which is what a cold
+        # cache must do.
+        self.assertIn('exclude = []', provider_cache.cli_config('/m', set()))
+
+
+class PackageTest(unittest.TestCase):
+    def _cache_with(self, root, kind):
+        path = os.path.join(root, 'registry.opentofu.org', 'hashicorp', 'null', '3.2.2')
+        os.makedirs(path, exist_ok=True)
+        target = os.path.join(path, 'linux_amd64')
+        if kind == 'dir':
+            os.makedirs(target, exist_ok=True)
+            _write(target, 'terraform-provider-null', b'x')
+        elif kind == 'link':
+            os.symlink(root, target)
+
+        return target
+
+    def test_downloaded_packages_finds_real_directories(self):
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, True)
+        self._cache_with(root, 'dir')
+        # tofu writes a sibling lock file next to the platform directory.
+        _write(os.path.join(root, 'registry.opentofu.org', 'hashicorp', 'null', '3.2.2'),
+               'linux_amd64.lock', b'')
+
+        packages = provider_cache.downloaded_packages(root)
+
+        self.assertEqual([(p[1], p[2], p[3]) for p in packages],
+                         [('registry.opentofu.org/hashicorp/null', '3.2.2', 'linux_amd64')])
+
+    def test_downloaded_packages_skips_mirror_symlinks(self):
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, True)
+        self._cache_with(root, 'link')
+
+        self.assertEqual(provider_cache.downloaded_packages(root), [])
+
+    def test_downloaded_packages_on_a_missing_directory(self):
+        self.assertEqual(provider_cache.downloaded_packages('/nonexistent-cache-dir'), [])
+
+    def test_zip_round_trip_keeps_content_hash_and_mode(self):
+        src = tempfile.mkdtemp()
+        dst = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, src, True)
+        self.addCleanup(shutil.rmtree, dst, True)
+        _write(src, 'terraform-provider-null', b'binary', mode=0o755)
+        _write(src, 'LICENSE', b'text', mode=0o644)
+        before = provider_cache.h1_of_dir(src)
+
+        self.assertTrue(provider_cache._unpack(provider_cache._zip_dir(src), dst))
+
+        self.assertEqual(provider_cache.h1_of_dir(dst), before)
+        self.assertEqual(os.stat(os.path.join(dst, 'terraform-provider-null')).st_mode & 0o777,
+                         0o755)
+
+    def test_unpack_refuses_a_zip_that_escapes_the_destination(self):
+        dst = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, dst, True)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('../escaped', 'x')
+
+        self.assertFalse(provider_cache._unpack(buf.getvalue(), dst))
+
+    def test_unpack_refuses_something_that_is_not_a_zip(self):
+        dst = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, dst, True)
+        self.assertFalse(provider_cache._unpack(b'not a zip', dst))
+
+
+def _state(capabilities=None, repo_config=None, env=None, api_base_url=None, installation_id='42'):
+    return SimpleNamespace(
+        api_base_url=api_base_url or 'https://app.terrateam.io/api/github',
+        api_token='tok',
+        env={} if env is None else env,
+        repo_config={'provider_cache': {'enabled': True}} if repo_config is None else repo_config,
+        work_manifest={
+            'capabilities': ['tenv', 'provider_cache'] if capabilities is None else capabilities,
+            'installation_id': installation_id,
+        })
+
+
+class EnabledTest(unittest.TestCase):
+    def test_enabled_when_the_server_offers_it_and_the_repo_asks_for_it(self):
+        self.assertTrue(provider_cache.enabled(_state()))
+
+    def test_disabled_without_the_capability(self):
+        self.assertFalse(provider_cache.enabled(_state(capabilities=['tenv'])))
+
+    def test_disabled_when_the_repo_config_does_not_ask_for_it(self):
+        self.assertFalse(provider_cache.enabled(_state(repo_config={})))
+        self.assertFalse(
+            provider_cache.enabled(_state(repo_config={'provider_cache': {'enabled': False}})))
+
+    def test_disabled_when_the_user_already_set_the_engine_variables(self):
+        self.assertFalse(
+            provider_cache.enabled(_state(env={'TF_CLI_CONFIG_FILE': '/etc/tfrc'})))
+        self.assertFalse(
+            provider_cache.enabled(_state(env={'TF_PLUGIN_CACHE_DIR': '/cache'})))
+
+
+class KvBaseTest(unittest.TestCase):
+    def test_the_kv_url_comes_from_the_api_base_url_and_the_installation(self):
+        self.assertEqual(provider_cache._kv_base(_state()),
+                         'https://app.terrateam.io/api/v1/github/kv/42')
+
+    def test_gitlab(self):
+        state = _state(api_base_url='https://tf.example.com/api/gitlab', installation_id='7')
+        self.assertEqual(provider_cache._kv_base(state),
+                         'https://tf.example.com/api/v1/gitlab/kv/7')
+
+    def test_no_url_without_an_installation_id(self):
+        self.assertIsNone(provider_cache._kv_base(_state(installation_id=None)))
+
+
+class PlatformTest(unittest.TestCase):
+    def test_platform_name_is_engine_shaped(self):
+        self.assertRegex(provider_cache.platform_name(), r'^[a-z0-9]+_[a-z0-9]+$')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/terrat_runner/work_exec.py
+++ b/terrat_runner/work_exec.py
@@ -14,6 +14,7 @@ import engine_stategraph
 import engine_terragrunt
 import engine_tf
 import hooks
+import provider_cache
 import repo_config as rc
 import results_compat
 import run_state
@@ -243,6 +244,8 @@ def _run(state, exec_cb):
     env['TERRATEAM_TMPDIR'] = state.tmpdir
     state = state._replace(env=env)
 
+    state = provider_cache.setup(state)
+
     pre_hooks = exec_cb.pre_hooks(state)
 
     logging.debug('EXEC : HOOKS : PRE')
@@ -279,6 +282,8 @@ def _run(state, exec_cb):
         state = state._replace(success=state.success and s.success)
         state = run_state.combine_secrets(state, s)
         steps.extend(r['outputs'])
+
+    provider_cache.store(state)
 
     logging.debug('EXEC : HOOKS : POST')
 


### PR DESCRIPTION
## Description

Runner half of the Terraform provider cache. Server half is stategraph/mono#2074; the issue is stategraph/mono#1650, phase 1 of stategraph/mono#1644.

`Engine.init` deletes `.terraform` before it runs, and the runner had no provider cache of any kind: no `TF_PLUGIN_CACHE_DIR`, no `TF_CLI_CONFIG_FILE`, no mirror. Every run re-downloaded every provider for every changed directory.

`provider_cache.py` now fills the cache and reads from it. Before the pre hooks it reads the `.terraform.lock.hcl` of each changed directory, fetches those providers from the Terrateam KV store into a local filesystem mirror, and points both engines at it. After all directories it uploads whatever the engines had to download. The server never talks to a registry; the runner fills the cache.

Both gates are off by default: the work manifest must carry the `provider_cache` capability, and the repository must set `provider_cache: enabled: true`. It also stands down, with a log line, when the user's own workflow already sets `TF_CLI_CONFIG_FILE` or `TF_PLUGIN_CACHE_DIR`.

## Why the key ends with the h1 hash

Only public registries are cached, and each provider is stored under the `h1` hash the lock file records for it. On fetch the hash is recomputed after unpacking and the bytes are discarded unless they match. A provider is therefore only ever used when the repository's own lock file already trusts those exact bytes, and any miss falls through to `direct` rather than failing the run.

This matters because of measured engine behaviour: with an `h1` for the platform in the lock file, both engines reject a tampered mirror (`doesn't match any of the checksums`, exit 1); with only `zh:` hashes they accept it and mark it `(unauthenticated)`. So a provider whose lock file has no usable `h1` is deliberately not served from the cache.

## Verification

95 tests pass, 31 new. Beyond the unit tests, the flow was run end to end against real OpenTofu 1.12.2 and Terraform 1.15.6: a cold run downloads and `downloaded_packages` finds exactly the new package; the zip, unpack and `h1` round-trip is exact; the warm run does `init` **and** `plan` with the registry blocked by an unreachable proxy.

Two defects that only showed up in that end to end run, both fixed and covered by tests:

- `h1` must sort file **names** and then emit a line per name, which is what Go's `dirhash.Hash1` does. Sorting the assembled lines orders by hash instead. A single-file package hides this, so `hashicorp/null` from `registry.terraform.io` matched while the same provider from `registry.opentofu.org`, which ships four files, did not. Both now reproduce the value the engines themselves wrote.
- `zipfile.extractall` drops the mode, so the unpacked provider binary lost its executable bit and the engine could not have run it. The mode now comes back from `external_attr`, verified at `0o755` with a real `tofu plan`.
