### PR TITLE
stategraph/mono#1992 FIX base image: refresh packages and bump the bundled tools

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,8 @@
-ARG BASE_IMAGE=debian:trixie-20260202-slim
+ARG BASE_IMAGE=debian:trixie-20260824-slim
 FROM ${BASE_IMAGE}
 
 RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	apt-utils \
 	bash \
@@ -26,27 +27,28 @@ RUN apt-get update \
 	unzip \
 	&& rm -rf /var/lib/apt/lists/*
 
-ARG TENV_LATEST_VERSION=v4.10.1
+ARG TENV_LATEST_VERSION=v4.15.1
 RUN echo "TENV_LATEST_VERSION: ${TENV_LATEST_VERSION}" && \
     ARCH=$(dpkg --print-architecture) && \
     curl -O -L "https://github.com/tofuutils/tenv/releases/download/${TENV_LATEST_VERSION}/tenv_${TENV_LATEST_VERSION}_${ARCH}.deb" && \
     dpkg -i "tenv_${TENV_LATEST_VERSION}_${ARCH}.deb" && \
     rm -f "tenv_${TENV_LATEST_VERSION}_${ARCH}.deb"
 
-ARG TOFU_VERSIONS=1.6.3,1.9.1
-ARG TERRAFORM_VERSIONS=1.5.7
+ARG TOFU_VERSIONS=1.12.6
+ARG TERRAFORM_VERSIONS=
 # Install tofu and terraform versions dynamically based on TOFU_VERSIONS and TERRAFORM_VERSIONS. versions should be comma separated.
-RUN for version in $(echo "${TOFU_VERSIONS}" | tr ',' ' '); do tenv tofu install ${version}; sleep 5; done && \
-    for version in $(echo "${TERRAFORM_VERSIONS}" | tr ',' ' '); do tenv terraform install ${version}; sleep 5; done
+RUN set -e; \
+    for version in $(echo "${TOFU_VERSIONS}" | tr ',' ' '); do tenv tofu install "${version}"; sleep 5; done; \
+    for version in $(echo "${TERRAFORM_VERSIONS}" | tr ',' ' '); do tenv terraform install "${version}"; sleep 5; done
 
-ENV INFRACOST_VERSION=v0.10.42
+ENV INFRACOST_VERSION=v0.10.45
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g') && \
     curl -fsSL -o /tmp/infracost-linux-${ARCH}.tar.gz "https://github.com/infracost/infracost/releases/download/${INFRACOST_VERSION}/infracost-linux-${ARCH}.tar.gz" && \
     tar -C /tmp -xzf /tmp/infracost-linux-${ARCH}.tar.gz && \
     mv /tmp/infracost-linux-${ARCH} /usr/local/bin/infracost && \
     rm -f /tmp/infracost-linux-${ARCH}.tar.gz
 
-ENV CONFTEST_VERSION=0.58.0
+ENV CONFTEST_VERSION=0.69.0
 RUN ARCH=$(uname -m | sed 's/aarch64/arm64/g') && \
     mkdir /tmp/conftest && \
     curl -fsSL -o /tmp/conftest/conftest.tar.gz "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz" && \
@@ -65,7 +67,7 @@ RUN echo "AWSCLI_VERSION: ${AWSCLI_VERSION}" && \
     /tmp/awscli/aws/install > /dev/null && \
     rm -rf /tmp/awscli
 
-ENV CHECKOV_VERSION=2.5.10
+ENV CHECKOV_VERSION=3.3.16
 RUN python3 -m venv /opt/checkov && \
     /opt/checkov/bin/pip install --no-cache-dir checkov==${CHECKOV_VERSION} && \
     ln -s /opt/checkov/bin/checkov /usr/local/bin/checkov


### PR DESCRIPTION
`ghcr.io/terrateamio/action:v1` is the largest item in the weekly container scan: 336 fixable HIGH/CRITICAL, 16 CRITICAL. It is also the image customers execute in their own CI. This refreshes `Dockerfile.base` so that a rebuild clears most of it.

### The build could not fail

```dockerfile
RUN for version in $(echo "${TERRAFORM_VERSIONS}" | tr ',' ' '); do tenv terraform install ${version}; sleep 5; done
```

A `for` loop returns the status of its last command, and that command is `sleep 5`. Docker runs this under `/bin/sh -c` with no `set -e`, so a failed install cannot fail the build.

It already happened. `Dockerfile` pins `action-base:1776595483`, built 2026-04-19 at 10:44 UTC. `9816ee6` ("FIX Expired HashiCorp public key") landed 13 minutes later, at 10:57 UTC. Terraform downloads are signed with that key. I scanned both base images directly: `action-base:1776595483` has no `root/.tenv/Terraform/1.5.7/terraform` target at all, and `action-base:1788374251` (built 2026-09-02, after the key fix) does. **The image we ship today contains no Terraform binary, and nothing reported it for five months.**

This is not a customer outage — `terrat_runner` sets `TOFUENV_REMOTE` and the `TENV_*` variables, so `tenv` fetches a missing version at run time and the baked binaries are only a warm cache. But the same silent failure would hide a broken OpenTofu install, and it makes every count in the scan unreliable. `set -e` on that `RUN` is the fix.

### Terraform is no longer baked in

`TERRAFORM_VERSIONS` now defaults to empty. Terraform 1.5.7 is the last MPL release, so it is the newest version we can ship, and it is frozen at Go 1.20.7 from August 2023. I scanned the binary: **62 fixable HIGH/CRITICAL, 5 CRITICAL, and no version bump will ever clear them.** Baking it in would put a permanent floor under the scan that can never reach zero, which is how a signal stops being read.

Nothing about Terraform support changes. `tenv` installs it on demand, exactly as it does today for the image that has no Terraform in it. The difference is that a customer who never selects Terraform no longer carries the binary. The `ARG` stays, so a build can opt back in.

### Measured effect on the bundled binaries

Each scanned standalone with trivy 0.70.0, the version CI uses:

| binary | now | after |
| --- | --- | --- |
| OpenTofu 1.6.3 | 62 / 5 | dropped |
| OpenTofu 1.9.1 | 52 / 3 | dropped |
| OpenTofu 1.12.6 | — | **12 / 1** |
| conftest 0.58.0 | 56 / 3 | — |
| conftest 0.69.0 | — | **20 / 1** |
| infracost v0.10.42 | 52 / 3 | — |
| infracost v0.10.45 | — | **16 / 1** |
| subtotal | 222 / 14 | **48 / 3** |

Dropping OpenTofu 1.6.3 and 1.9.1 from the bake does not drop support for them. `tenv` still installs any version a customer pins; they stop being a pre-warmed cache entry, nothing more.

### Measured effect on the OS and Python layers

`Dockerfile.base` ran `apt-get update` and `apt-get install` with no `apt-get upgrade`, so packages the Debian snapshot pre-installed kept their February versions. All 90 OS findings have a `deb13uN` security update available. This adds the upgrade and moves the snapshot from `trixie-20260202-slim` to `trixie-20260824-slim`.

For an upper bound I scanned `action-base:1788374251`, a 2026-09-02 build of this file *before* these changes: OS packages **27 / 0** against today's 90 / 2, and the checkov venv **2 / 0** against today's 24 / 0. This PR should land at or below those, since it adds the upgrade step and a newer snapshot.

### Also bumped

`tenv` v4.10.1 → v4.15.1, `checkov` 2.5.10 → 3.3.16. checkov crosses a major version and needs a test run before merge.

### Verification

- Every release asset referenced by the new versions confirmed to exist for both `amd64`/`x86_64` and `arm64`.
- `debian:trixie-20260824-slim` and `checkov==3.3.16` confirmed to exist.
- The rewritten `RUN` passes `sh -n`; a failing command inside the loop now exits non-zero; an empty `TERRAFORM_VERSIONS` is a clean no-op rather than an error.

### Not addressed here

`AWSCLI_VERSION` is dead. The download URL is `awscli-exe-linux-${ARCH}.zip`, which carries no version, so the `ARG` has never pinned anything. Left alone deliberately.

After this merges, `base.yaml` needs a manual run and then `Dockerfile`'s `BASE_IMAGE` needs repointing to the new tag.
