### PR TITLE
ADD native support for Terragrunt Stacks

### DIFF
--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -152,7 +152,11 @@ class Engine(engine_tf.Engine):
                 target = os.path.abspath(os.path.join(workspace, member.name))
                 if os.path.commonpath([workspace, target]) != workspace:
                     raise ValueError('Stack plan artifact contains an unsafe path')
-            tar.extractall(state.working_dir, members=plan_members)
+            # filter='data' additionally rejects symlink/hardlink members whose
+            # link target escapes the extraction directory (CVE-2007-4559-class),
+            # and device/fifo members -- the commonpath check above only covers
+            # a member's own name, not what a symlink member points at.
+            tar.extractall(state.working_dir, members=plan_members, filter='data')
             stack_config = tar.extractfile('stack/terragrunt.stack.hcl').read()
 
         if hashlib.sha256(stack_config).hexdigest() != manifest['stack_config_sha256']:

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -1,3 +1,5 @@
+import hashlib
+import io
 import json
 import logging
 import os
@@ -10,6 +12,8 @@ import engine_tf
 
 
 CLI_REDESIGN_VERSION = (0, 88, 0)
+STACK_ARTIFACT_MANIFEST = '.terrateam-stack-artifact.json'
+STACK_ARTIFACT_VERSION = 1
 
 
 def _parse_version(version):
@@ -21,17 +25,6 @@ def _parse_version(version):
         return None
 
     return tuple(int(part) for part in match.groups())
-
-
-def _tar_dir(src_dir, dest_file):
-    with tarfile.open(dest_file, 'w') as tar:
-        tar.add(src_dir, arcname='.')
-
-
-def _untar_dir(src_file, dest_dir):
-    os.makedirs(dest_dir, exist_ok=True)
-    with tarfile.open(src_file, 'r') as tar:
-        tar.extractall(dest_dir)
 
 
 class Engine(engine_tf.Engine):
@@ -102,6 +95,79 @@ class Engine(engine_tf.Engine):
         # (terrateam/cmd/s3 plan storage) need no changes at all.
         return os.path.join(state.working_dir, '.terrateam-stack-plans')
 
+    def _stack_config_path(self, state):
+        return os.path.join(state.working_dir, 'terragrunt.stack.hcl')
+
+    def _stack_artifact_manifest(self, state, stack_config):
+        return {
+            'format_version': STACK_ARTIFACT_VERSION,
+            'engine': 'terragrunt-stack',
+            'stack_root': state.path,
+            'stack_config_sha256': hashlib.sha256(stack_config).hexdigest(),
+        }
+
+    def _tar_stack_artifact(self, state):
+        # A Stack plan is a collection of Terraform plans plus the root Stack
+        # configuration that evaluates `values` during `stack run apply`.
+        # Runtime directories (.terraform and .terragrunt-cache) are neither
+        # portable nor needed: Terragrunt recreates them in the apply worker.
+        with open(self._stack_config_path(state), 'rb') as f:
+            stack_config = f.read()
+
+        manifest = json.dumps(self._stack_artifact_manifest(state, stack_config)).encode('utf-8')
+        with tarfile.open(state.env['TERRATEAM_PLAN_FILE'], 'w') as tar:
+            tar.add(self._stack_units_dir(state), arcname='.terrateam-stack-plans')
+            info = tarfile.TarInfo(STACK_ARTIFACT_MANIFEST)
+            info.size = len(manifest)
+            tar.addfile(info, io.BytesIO(manifest))
+            info = tarfile.TarInfo('stack/terragrunt.stack.hcl')
+            info.size = len(stack_config)
+            tar.addfile(info, io.BytesIO(stack_config))
+
+    def _load_stack_artifact_manifest(self, state):
+        try:
+            with tarfile.open(state.env['TERRATEAM_PLAN_FILE'], 'r') as tar:
+                member = tar.getmember(STACK_ARTIFACT_MANIFEST)
+                content = tar.extractfile(member).read()
+                manifest = json.loads(content)
+        except (KeyError, OSError, tarfile.TarError, json.JSONDecodeError, AttributeError):
+            return None
+
+        if (not isinstance(manifest, dict)
+                or manifest.get('format_version') != STACK_ARTIFACT_VERSION
+                or manifest.get('engine') != 'terragrunt-stack'
+                or not isinstance(manifest.get('stack_root'), str)
+                or not isinstance(manifest.get('stack_config_sha256'), str)):
+            return None
+
+        return manifest
+
+    def _restore_stack_artifact(self, state, manifest):
+        with tarfile.open(state.env['TERRATEAM_PLAN_FILE'], 'r') as tar:
+            plan_members = [member for member in tar.getmembers()
+                            if member.name == '.terrateam-stack-plans'
+                            or member.name.startswith('.terrateam-stack-plans/')]
+            workspace = os.path.abspath(state.working_dir)
+            for member in plan_members:
+                target = os.path.abspath(os.path.join(workspace, member.name))
+                if os.path.commonpath([workspace, target]) != workspace:
+                    raise ValueError('Stack plan artifact contains an unsafe path')
+            tar.extractall(state.working_dir, members=plan_members)
+            stack_config = tar.extractfile('stack/terragrunt.stack.hcl').read()
+
+        if hashlib.sha256(stack_config).hexdigest() != manifest['stack_config_sha256']:
+            raise ValueError('Stack artifact configuration checksum does not match its manifest')
+
+        config_path = self._stack_config_path(state)
+        if os.path.exists(config_path):
+            with open(config_path, 'rb') as f:
+                current_config = f.read()
+            if current_config != stack_config:
+                raise ValueError('Stack root configuration changed after plan; run a new plan before apply')
+        else:
+            with open(config_path, 'wb') as f:
+                f.write(stack_config)
+
     def _stack_plan_has_changes(self, state):
         # Some Terragrunt versions return zero from `stack run plan` even
         # when -detailed-exitcode is forwarded and the generated unit plans
@@ -161,35 +227,29 @@ class Engine(engine_tf.Engine):
             if not ok:
                 return (False, False, stdout, '\n'.join(v for v in [stderr, inspect_stderr] if v))
 
-        _tar_dir(out_dir, state.env['TERRATEAM_PLAN_FILE'])
+        self._tar_stack_artifact(state)
         return (True, has_changes, stdout, stderr)
 
     def apply(self, state, config):
-        if not self._is_stack(state):
+        manifest = self._load_stack_artifact_manifest(state)
+        if manifest is None:
+            if self._is_stack(state):
+                return (False, '', 'Terragrunt Stack plan artifact is missing or invalid; run a new plan before apply')
             return super().apply(state, config)
+
+        if manifest['stack_root'] != state.path:
+            return (False, '', 'Stack plan belongs to a different directory; run a new plan before apply')
 
         logging.info(
             'APPLY : %s : engine=%s : stack=true',
             state.path,
             state.workflow['engine']['name'])
 
+        try:
+            self._restore_stack_artifact(state, manifest)
+        except (OSError, tarfile.TarError, ValueError) as exn:
+            return (False, '', 'Unable to restore Terragrunt Stack plan artifact: {}'.format(exn))
         out_dir = self._stack_units_dir(state)
-        _untar_dir(state.env['TERRATEAM_PLAN_FILE'], out_dir)
-
-        # Stack units are generated at plan time but apply runs in a fresh
-        # checkout. Regenerate them so `stack run apply` can locate each
-        # unit's terragrunt.hcl while using the saved plan files below.
-        (proc, stdout, stderr) = cmd.run_with_output(
-            state,
-            {
-                'cmd': [
-                    self.tf_cmd, 'stack', 'generate',
-                    '--non-interactive',
-                ]
-            })
-
-        if proc.returncode != 0:
-            return (False, stdout, stderr)
 
         (proc, stdout, stderr) = cmd.run_with_output(
             state,
@@ -198,21 +258,21 @@ class Engine(engine_tf.Engine):
                     self.tf_cmd, 'stack', 'run', 'apply',
                     '--out-dir', out_dir,
                     '--non-interactive',
-                    '--',
                 ] + config.get('extra_args', [])
             })
 
-        # Terraform itself refuses to apply a saved plan if any input variable
-        # no longer matches what was recorded at plan time ("Can't change
-        # variable when applying a saved plan") -- confirmed by deliberately
-        # changing a unit's input between plan and apply in local testing.
-        # That guarantee is enforced by Terraform, not by this engine.
+        # `stack run` regenerates the units with the root Stack's values and
+        # preserves their dependency order. Terraform refuses a saved plan if
+        # its recorded inputs or state are stale.
         return (proc.returncode == 0, stdout, stderr)
 
     def _stack_show(self, state, extra_args):
         out_dir = self._stack_units_dir(state)
         if not os.path.isdir(out_dir):
-            _untar_dir(state.env['TERRATEAM_PLAN_FILE'], out_dir)
+            manifest = self._load_stack_artifact_manifest(state)
+            if manifest is None:
+                return (False, [])
+            self._restore_stack_artifact(state, manifest)
 
         results = []
         overall_ok = True

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -191,6 +191,24 @@ class Engine(engine_tf.Engine):
 
         return (True, False, '')
 
+    def init(self, state, config, create_and_select_workspace=None):
+        if not self._is_stack(state):
+            return super().init(state, config, create_and_select_workspace)
+
+        # engine_tf.Engine.init() runs plain `terragrunt init` (plus workspace
+        # select/new) with cwd=state.working_dir, i.e. the Stack root -- same
+        # "does not contain a terragrunt.hcl file" failure as outputs()/show,
+        # for the same reason. `terragrunt stack run plan`/`apply` initialize
+        # each generated unit themselves, so this step is redundant for a
+        # Stack, not just unsafe to run as-is. This only matters for repo
+        # configs that don't override the default `plan`/`apply` workflows --
+        # those default to `[{type: init}, {type: plan/apply}]`.
+        logging.info(
+            'INIT : %s : engine=%s : stack=true : skipped (stack run plan/apply initialize each unit themselves)',
+            state.path,
+            state.workflow['engine']['name'])
+        return (True, '', '')
+
     def plan(self, state, config):
         if not self._is_stack(state):
             return super().plan(state, config)
@@ -264,6 +282,33 @@ class Engine(engine_tf.Engine):
         # `stack run` regenerates the units with the root Stack's values and
         # preserves their dependency order. Terraform refuses a saved plan if
         # its recorded inputs or state are stale.
+        return (proc.returncode == 0, stdout, stderr)
+
+    def apply_without_plan(self, state, config):
+        if not self._is_stack(state):
+            return super().apply_without_plan(state, config)
+
+        logging.info(
+            'APPLY_WITHOUT_PLAN : %s : engine=%s : stack=true',
+            state.path,
+            state.workflow['engine']['name'])
+
+        # There is no saved plan artifact to restore here (that's the whole
+        # point of apply_without_plan) -- `stack run apply` generates the
+        # units and applies live in one step, same as plain `terraform apply
+        # -auto-approve` does for a non-stack directory.
+        out_dir = self._stack_units_dir(state)
+
+        (proc, stdout, stderr) = cmd.run_with_output(
+            state,
+            {
+                'cmd': [
+                    self.tf_cmd, 'stack', 'run', 'apply',
+                    '--out-dir', out_dir,
+                    '--non-interactive',
+                ] + config.get('extra_args', [])
+            })
+
         return (proc.returncode == 0, stdout, stderr)
 
     def _stack_show(self, state, extra_args):
@@ -344,6 +389,25 @@ class Engine(engine_tf.Engine):
         except json.JSONDecodeError as exn:
             stdout = '\n'.join(out for (_unit, _unit_ok, out, _err) in results)
             return (False, stdout, str(exn))
+
+    def outputs(self, state, config):
+        if not self._is_stack(state):
+            return super().outputs(state, config)
+
+        # engine_tf.Engine.outputs() runs plain `terragrunt output -json` with
+        # cwd=state.working_dir, i.e. the Stack root -- which only ever has
+        # terragrunt.stack.hcl, never terragrunt.hcl, so it always fails with
+        # "does not contain a terragrunt.hcl file". A Stack has no single
+        # root-level output set (each unit has its own); skipping collection
+        # entirely -- the same `None` the base class itself returns when
+        # outputs collection is disabled via config -- is already handled
+        # correctly by workflow_step_apply.py. Aggregating per-unit outputs is
+        # a separate, bigger feature (namespacing, rendering) left for later.
+        logging.info(
+            'OUTPUTS : %s : engine=%s : stack=true : skipped (no single root-level output set for a stack)',
+            state.path,
+            state.workflow['engine']['name'])
+        return None
 
 
 def make(**options):

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -176,6 +176,21 @@ class Engine(engine_tf.Engine):
         out_dir = self._stack_units_dir(state)
         _untar_dir(state.env['TERRATEAM_PLAN_FILE'], out_dir)
 
+        # Stack units are generated at plan time but apply runs in a fresh
+        # checkout. Regenerate them so `stack run apply` can locate each
+        # unit's terragrunt.hcl while using the saved plan files below.
+        (proc, stdout, stderr) = cmd.run_with_output(
+            state,
+            {
+                'cmd': [
+                    self.tf_cmd, 'stack', 'generate',
+                    '--non-interactive',
+                ]
+            })
+
+        if proc.returncode != 0:
+            return (False, stdout, stderr)
+
         (proc, stdout, stderr) = cmd.run_with_output(
             state,
             {

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -177,9 +177,22 @@ class Engine(engine_tf.Engine):
             unit = os.path.relpath(dirpath, out_dir)
             plan_path = os.path.join(dirpath, 'tfplan.tfplan')
 
+            # --out-dir only copies the plan file, not the unit's
+            # terragrunt.hcl -- that only exists where `terragrunt stack
+            # generate` originally wrote it, under working_dir itself, not
+            # under out_dir. Plain `terragrunt show` run with cwd=working_dir
+            # (cmd.run_with_output always uses state.working_dir, it has no
+            # per-call cwd override) fails with "does not contain a
+            # terragrunt.hcl file" because that's the stack root, which only
+            # has terragrunt.stack.hcl. --working-dir points terragrunt at
+            # the real generated unit directory instead, without needing to
+            # touch cwd at all. Confirmed against a real Terragrunt 1.1.4
+            # install; the flag must come before the `show` subcommand.
+            unit_config_dir = os.path.join(state.working_dir, unit)
+
             (proc, stdout, stderr) = cmd.run_with_output(
                 state,
-                {'cmd': [self.tf_cmd, 'show'] + extra_args + [plan_path]})
+                {'cmd': [self.tf_cmd, '--working-dir', unit_config_dir, 'show'] + extra_args + [plan_path]})
 
             overall_ok = overall_ok and proc.returncode == 0
             results.append((unit, proc.returncode == 0, stdout, stderr))

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -102,6 +102,29 @@ class Engine(engine_tf.Engine):
         # (terrateam/cmd/s3 plan storage) need no changes at all.
         return os.path.join(state.working_dir, '.terrateam-stack-plans')
 
+    def _stack_plan_has_changes(self, state):
+        # Some Terragrunt versions return zero from `stack run plan` even
+        # when -detailed-exitcode is forwarded and the generated unit plans
+        # contain changes. Inspect those saved plans as a safe fallback: a
+        # false negative here would make Terrateam silently skip apply.
+        (ok, results) = self._stack_show(state, ['-json'])
+        if not ok:
+            stderr = '\n'.join(
+                err for (_unit, unit_ok, _out, err) in results if not unit_ok)
+            return (False, False, stderr or 'Unable to inspect Terragrunt stack plans')
+
+        try:
+            for (_unit, _unit_ok, stdout, _stderr) in results:
+                plan = json.loads(stdout)
+                changes = plan.get('resource_changes', []) + list(plan.get('output_changes', {}).values())
+                for change in changes:
+                    if change.get('change', {}).get('actions', []) != ['no-op']:
+                        return (True, True, '')
+        except (AttributeError, json.JSONDecodeError) as exn:
+            return (False, False, 'Unable to parse Terragrunt stack plan JSON: {}'.format(exn))
+
+        return (True, False, '')
+
     def plan(self, state, config):
         if not self._is_stack(state):
             return super().plan(state, config)
@@ -125,13 +148,21 @@ class Engine(engine_tf.Engine):
                 ] + config.get('extra_args', [])
             })
 
-        # -detailed-exitcode must be forwarded via `--`, or `stack run` never
-        # returns 2 for "has changes" -- confirmed against a real Terragrunt
-        # 1.1.4 install; without `--` the process always exits 0/1.
-        if proc.returncode in [0, 2]:
-            _tar_dir(out_dir, state.env['TERRATEAM_PLAN_FILE'])
+        # -detailed-exitcode must be forwarded via `--`. Some Terragrunt
+        # versions nevertheless return zero for stack plans with changes, so
+        # use the generated unit plan JSON as a fallback before recording
+        # has_changes=false.
+        if proc.returncode not in [0, 2]:
+            return (False, False, stdout, stderr)
 
-        return (proc.returncode in [0, 2], proc.returncode == 2, stdout, stderr)
+        has_changes = proc.returncode == 2
+        if not has_changes:
+            (ok, has_changes, inspect_stderr) = self._stack_plan_has_changes(state)
+            if not ok:
+                return (False, False, stdout, '\n'.join(v for v in [stderr, inspect_stderr] if v))
+
+        _tar_dir(out_dir, state.env['TERRATEAM_PLAN_FILE'])
+        return (True, has_changes, stdout, stderr)
 
     def apply(self, state, config):
         if not self._is_stack(state):

--- a/terrat_runner/engine_terragrunt.py
+++ b/terrat_runner/engine_terragrunt.py
@@ -1,6 +1,12 @@
-import engine_tf
+import json
+import logging
+import os
 import re
 import subprocess
+import tarfile
+
+import cmd
+import engine_tf
 
 
 CLI_REDESIGN_VERSION = (0, 88, 0)
@@ -17,11 +23,23 @@ def _parse_version(version):
     return tuple(int(part) for part in match.groups())
 
 
+def _tar_dir(src_dir, dest_file):
+    with tarfile.open(dest_file, 'w') as tar:
+        tar.add(src_dir, arcname='.')
+
+
+def _untar_dir(src_file, dest_dir):
+    os.makedirs(dest_dir, exist_ok=True)
+    with tarfile.open(src_file, 'r') as tar:
+        tar.extractall(dest_dir)
+
+
 class Engine(engine_tf.Engine):
     def __init__(self, name, override_tf_cmd, **options):
         super().__init__(name, override_tf_cmd, **options)
         self.version = options.get('version')
         self.__use_run_for_workspace = None
+        self.__is_stack = None
 
     def _detect_installed_version(self, state):
         try:
@@ -60,6 +78,153 @@ class Engine(engine_tf.Engine):
             return [self.tf_cmd, 'run', '--', 'workspace'] + list(args)
         else:
             return super().workspace_cmd(state, *args)
+
+    def _is_stack(self, state):
+        # Terragrunt Stacks (terragrunt.stack.hcl) have no terragrunt.hcl of
+        # their own, so plain `terragrunt plan`/`apply` cannot run there at
+        # all -- they need `terragrunt stack run <verb>` instead. Detecting
+        # this here (at command-construction time, from the filesystem)
+        # rather than via repo config works because by the time plan/apply
+        # run, the directory is always already checked out on disk.
+        if self.__is_stack is None:
+            self.__is_stack = os.path.exists(
+                os.path.join(state.working_dir, 'terragrunt.stack.hcl'))
+        return self.__is_stack
+
+    def _stack_units_dir(self, state):
+        # A stack's `stack run` produces one plan file per unit, not the
+        # single file Terrateam's plan-storage plumbing (TERRATEAM_PLAN_FILE)
+        # assumes. Rather than teach the storage layer about directories, we
+        # keep the directory of per-unit plan files local to this job (under
+        # the checkout, alongside Terragrunt's own .terragrunt-stack/
+        # .terragrunt-cache/) and tar/untar it into TERRATEAM_PLAN_FILE at the
+        # plan/apply boundary, so every other engine and the storage layer
+        # (terrateam/cmd/s3 plan storage) need no changes at all.
+        return os.path.join(state.working_dir, '.terrateam-stack-plans')
+
+    def plan(self, state, config):
+        if not self._is_stack(state):
+            return super().plan(state, config)
+
+        logging.info(
+            'PLAN : %s : engine=%s : stack=true',
+            state.path,
+            state.workflow['engine']['name'])
+
+        out_dir = self._stack_units_dir(state)
+
+        (proc, stdout, stderr) = cmd.run_with_output(
+            state,
+            {
+                'cmd': [
+                    self.tf_cmd, 'stack', 'run', 'plan',
+                    '--out-dir', out_dir,
+                    '--non-interactive',
+                    '--',
+                    '-detailed-exitcode',
+                ] + config.get('extra_args', [])
+            })
+
+        # -detailed-exitcode must be forwarded via `--`, or `stack run` never
+        # returns 2 for "has changes" -- confirmed against a real Terragrunt
+        # 1.1.4 install; without `--` the process always exits 0/1.
+        if proc.returncode in [0, 2]:
+            _tar_dir(out_dir, state.env['TERRATEAM_PLAN_FILE'])
+
+        return (proc.returncode in [0, 2], proc.returncode == 2, stdout, stderr)
+
+    def apply(self, state, config):
+        if not self._is_stack(state):
+            return super().apply(state, config)
+
+        logging.info(
+            'APPLY : %s : engine=%s : stack=true',
+            state.path,
+            state.workflow['engine']['name'])
+
+        out_dir = self._stack_units_dir(state)
+        _untar_dir(state.env['TERRATEAM_PLAN_FILE'], out_dir)
+
+        (proc, stdout, stderr) = cmd.run_with_output(
+            state,
+            {
+                'cmd': [
+                    self.tf_cmd, 'stack', 'run', 'apply',
+                    '--out-dir', out_dir,
+                    '--non-interactive',
+                    '--',
+                ] + config.get('extra_args', [])
+            })
+
+        # Terraform itself refuses to apply a saved plan if any input variable
+        # no longer matches what was recorded at plan time ("Can't change
+        # variable when applying a saved plan") -- confirmed by deliberately
+        # changing a unit's input between plan and apply in local testing.
+        # That guarantee is enforced by Terraform, not by this engine.
+        return (proc.returncode == 0, stdout, stderr)
+
+    def _stack_show(self, state, extra_args):
+        out_dir = self._stack_units_dir(state)
+        if not os.path.isdir(out_dir):
+            _untar_dir(state.env['TERRATEAM_PLAN_FILE'], out_dir)
+
+        results = []
+        overall_ok = True
+        for dirpath, _dirnames, filenames in os.walk(out_dir):
+            if 'tfplan.tfplan' not in filenames:
+                continue
+
+            unit = os.path.relpath(dirpath, out_dir)
+            plan_path = os.path.join(dirpath, 'tfplan.tfplan')
+
+            (proc, stdout, stderr) = cmd.run_with_output(
+                state,
+                {'cmd': [self.tf_cmd, 'show'] + extra_args + [plan_path]})
+
+            overall_ok = overall_ok and proc.returncode == 0
+            results.append((unit, proc.returncode == 0, stdout, stderr))
+
+        return (overall_ok, results)
+
+    def diff(self, state, config):
+        if not self._is_stack(state):
+            return super().diff(state, config)
+
+        logging.info(
+            'DIFF : %s : engine=%s : stack=true',
+            state.path,
+            state.workflow['engine']['name'])
+
+        (ok, results) = self._stack_show(state, [])
+
+        stdout = '\n\n'.join(
+            '# unit: {}\n{}'.format(unit, engine_tf.format_diff(out))
+            for (unit, unit_ok, out, _err) in results if unit_ok)
+        stderr = '\n'.join(err for (_unit, unit_ok, _out, err) in results if not unit_ok)
+
+        return (ok, stdout, stderr)
+
+    def diff_json(self, state, config):
+        if not self._is_stack(state):
+            return super().diff_json(state, config)
+
+        logging.info(
+            'DIFF_JSON : %s : engine=%s : stack=true',
+            state.path,
+            state.workflow['engine']['name'])
+
+        (ok, results) = self._stack_show(state, ['-json'])
+
+        if not ok:
+            stdout = '\n'.join(out for (_unit, _unit_ok, out, _err) in results)
+            stderr = '\n'.join(err for (_unit, unit_ok, _out, err) in results if not unit_ok)
+            return (False, stdout, stderr)
+
+        try:
+            return (True, {unit: json.loads(out) for (unit, _ok, out, _err) in results})
+        except json.JSONDecodeError as exn:
+            stdout = '\n'.join(out for (_unit, _unit_ok, out, _err) in results)
+            return (False, stdout, str(exn))
 
 
 def make(**options):

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -244,6 +244,32 @@ class RestoreStackArtifactTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'changed after plan'):
                 engine._restore_stack_artifact(state, manifest)
 
+    def test_rejects_symlink_member_escaping_workspace(self):
+        # A member's own name can look safe (no "..", stays under
+        # .terrateam-stack-plans/) while still being a symlink whose link
+        # target escapes the workspace -- a later apply() run reuses this
+        # same directory as Terragrunt's --out-dir, so a symlink planted here
+        # would redirect Terragrunt's real writes outside the checkout
+        # (CVE-2007-4559-class). The name-only commonpath check does not
+        # catch this; extractall's filter='data' does.
+        with tempfile.TemporaryDirectory() as d:
+            plan_file = os.path.join(d, 'plan.tar')
+            state = _state(d)
+            state.env['TERRATEAM_PLAN_FILE'] = plan_file
+            self._make_artifact(plan_file, stack_config=b'unit "app" {}')
+
+            with tarfile.open(plan_file, 'a') as tar:
+                link_info = tarfile.TarInfo('.terrateam-stack-plans/evil')
+                link_info.type = tarfile.SYMTYPE
+                link_info.linkname = '/etc'
+                tar.addfile(link_info)
+
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            manifest = engine._load_stack_artifact_manifest(state)
+
+            with self.assertRaises(tarfile.TarError):
+                engine._restore_stack_artifact(state, manifest)
+
 
 class StackPlanChangesTest(unittest.TestCase):
     def test_resource_change_is_detected(self):

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -1,0 +1,196 @@
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import engine_terragrunt
+
+
+def _state(working_dir, **extra):
+    return SimpleNamespace(
+        path='.',
+        working_dir=working_dir,
+        workflow={'engine': {'name': 'terragrunt'}},
+        env={'TERRATEAM_PLAN_FILE': '/tmp/plan', 'TG_DEFAULT_VERSION': 'latest'},
+        **extra)
+
+
+class IsStackTest(unittest.TestCase):
+    def test_true_when_stack_file_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            self.assertTrue(engine._is_stack(_state(d)))
+
+    def test_false_when_stack_file_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            self.assertFalse(engine._is_stack(_state(d)))
+
+    def test_result_is_cached(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+            self.assertFalse(engine._is_stack(state))
+            # Even if a stack file shows up afterwards, the cached engine
+            # instance should not re-detect -- one Engine is used for one
+            # dirspace for the lifetime of a job.
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            self.assertFalse(engine._is_stack(state))
+
+
+class PlanTest(unittest.TestCase):
+    def test_non_stack_dir_delegates_to_base_engine(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                engine.plan(state, {})
+
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'plan', '-detailed-exitcode', '-out', '${TERRATEAM_PLAN_FILE}'])
+
+    def test_stack_dir_uses_stack_run_plan(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._tar_dir') as tar_dir:
+                run.return_value = (SimpleNamespace(returncode=2), 'out', 'err')
+                result = engine.plan(state, {'extra_args': ['-var=foo=bar']})
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'stack', 'run', 'plan',
+                 '--out-dir', out_dir,
+                 '--non-interactive',
+                 '--',
+                 '-detailed-exitcode',
+                 '-var=foo=bar'])
+            # exit code 2 == has changes, and must still be treated as success.
+            self.assertEqual(result, (True, True, 'out', 'err'))
+            tar_dir.assert_called_once_with(out_dir, '/tmp/plan')
+
+    def test_stack_plan_failure_does_not_tar(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._tar_dir') as tar_dir:
+                run.return_value = (SimpleNamespace(returncode=1), 'out', 'err')
+                result = engine.plan(state, {})
+
+            self.assertEqual(result, (False, False, 'out', 'err'))
+            tar_dir.assert_not_called()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_non_stack_dir_delegates_to_base_engine(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                engine.apply(state, {})
+
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'apply', '${TERRATEAM_PLAN_FILE}'])
+
+    def test_stack_dir_untars_then_uses_stack_run_apply(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._untar_dir') as untar_dir:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                result = engine.apply(state, {})
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            untar_dir.assert_called_once_with('/tmp/plan', out_dir)
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'stack', 'run', 'apply',
+                 '--out-dir', out_dir,
+                 '--non-interactive',
+                 '--'])
+            self.assertEqual(result, (True, 'out', 'err'))
+
+
+class StackShowTest(unittest.TestCase):
+    def _make_unit_plan(self, out_dir, unit):
+        unit_dir = os.path.join(out_dir, unit)
+        os.makedirs(unit_dir, exist_ok=True)
+        open(os.path.join(unit_dir, 'tfplan.tfplan'), 'w').close()
+
+    def test_diff_concatenates_all_units(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            self._make_unit_plan(out_dir, 'vpc')
+            self._make_unit_plan(out_dir, 'app')
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'no changes', 'err')
+                (ok, stdout, stderr) = engine.diff(state, {})
+
+            self.assertTrue(ok)
+            self.assertIn('# unit: vpc', stdout)
+            self.assertIn('# unit: app', stdout)
+            self.assertEqual(run.call_count, 2)
+
+    def test_diff_json_returns_dict_keyed_by_unit(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            self._make_unit_plan(out_dir, 'vpc')
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), '{"format_version": "1.0"}', 'err')
+                (ok, payload) = engine.diff_json(state, {})
+
+            self.assertTrue(ok)
+            self.assertEqual(payload, {'vpc': {'format_version': '1.0'}})
+
+    def test_diff_untars_when_units_dir_missing(self):
+        # Simulates a fresh job (e.g. a re-run) where the plan directory was
+        # never populated by plan() in this process and must come back from
+        # TERRATEAM_PLAN_FILE instead.
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+
+            def fake_untar(_src, dest):
+                self._make_unit_plan(dest, 'vpc')
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._untar_dir', side_effect=fake_untar) as untar_dir:
+                run.return_value = (SimpleNamespace(returncode=0), 'no changes', 'err')
+                engine.diff(state, {})
+
+            untar_dir.assert_called_once_with('/tmp/plan', out_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -1,3 +1,5 @@
+import hashlib
+import io
 import json
 import os
 import tarfile
@@ -40,6 +42,38 @@ class IsStackTest(unittest.TestCase):
             # dirspace for the lifetime of a job.
             open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
             self.assertFalse(engine._is_stack(state))
+
+
+class InitTest(unittest.TestCase):
+    def test_non_stack_dir_delegates_to_base_engine(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                result = engine.init(state, {}, create_and_select_workspace=False)
+
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['flock', '/tmp/tf-init.lock', 'terragrunt', 'init'])
+            self.assertEqual(result, (True, 'out', 'err'))
+
+    def test_stack_dir_skips_init(self):
+        # terragrunt init in the Stack root fails the same way outputs()/show
+        # do (no terragrunt.hcl there); `stack run plan`/`apply` initialize
+        # each generated unit themselves, so this step is a no-op for a
+        # Stack, not just unsafe to run as written.
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                result = engine.init(state, {})
+
+            self.assertEqual(result, (True, '', ''))
+            run.assert_not_called()
 
 
 class PlanTest(unittest.TestCase):
@@ -153,6 +187,64 @@ class StackArtifactTest(unittest.TestCase):
             self.assertEqual(engine._load_stack_artifact_manifest(state)['engine'], 'terragrunt-stack')
 
 
+class RestoreStackArtifactTest(unittest.TestCase):
+    def _make_artifact(self, plan_file, stack_config, manifest_config_for_hash=None):
+        manifest_bytes = json.dumps({
+            'format_version': engine_terragrunt.STACK_ARTIFACT_VERSION,
+            'engine': 'terragrunt-stack',
+            'stack_root': '.',
+            'stack_config_sha256': hashlib.sha256(manifest_config_for_hash or stack_config).hexdigest(),
+        }).encode('utf-8')
+        with tarfile.open(plan_file, 'w') as tar:
+            info = tarfile.TarInfo(engine_terragrunt.STACK_ARTIFACT_MANIFEST)
+            info.size = len(manifest_bytes)
+            tar.addfile(info, io.BytesIO(manifest_bytes))
+            info = tarfile.TarInfo('stack/terragrunt.stack.hcl')
+            info.size = len(stack_config)
+            tar.addfile(info, io.BytesIO(stack_config))
+            plans_dir_info = tarfile.TarInfo('.terrateam-stack-plans')
+            plans_dir_info.type = tarfile.DIRTYPE
+            tar.addfile(plans_dir_info)
+
+    def test_rejects_when_checksum_does_not_match_manifest(self):
+        # Simulates a corrupted or hand-edited artifact: the manifest's
+        # recorded hash doesn't match what's actually stored in the tar.
+        with tempfile.TemporaryDirectory() as d:
+            plan_file = os.path.join(d, 'plan.tar')
+            state = _state(d)
+            state.env['TERRATEAM_PLAN_FILE'] = plan_file
+            self._make_artifact(
+                plan_file,
+                stack_config=b'unit "app" {}',
+                manifest_config_for_hash=b'unit "other" {}')
+
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            manifest = engine._load_stack_artifact_manifest(state)
+
+            with self.assertRaisesRegex(ValueError, 'checksum does not match'):
+                engine._restore_stack_artifact(state, manifest)
+
+    def test_rejects_when_root_config_changed_after_plan(self):
+        # Simulates a later commit landing on the apply checkout's branch
+        # between plan and apply that edits the Stack root config -- applying
+        # the old saved plan against a changed root config could apply
+        # against the wrong values/units.
+        with tempfile.TemporaryDirectory() as d:
+            plan_file = os.path.join(d, 'plan.tar')
+            state = _state(d)
+            state.env['TERRATEAM_PLAN_FILE'] = plan_file
+            self._make_artifact(plan_file, stack_config=b'unit "app" {}')
+
+            with open(os.path.join(d, 'terragrunt.stack.hcl'), 'wb') as f:
+                f.write(b'unit "app" {}\nunit "extra" {}')
+
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            manifest = engine._load_stack_artifact_manifest(state)
+
+            with self.assertRaisesRegex(ValueError, 'changed after plan'):
+                engine._restore_stack_artifact(state, manifest)
+
+
 class StackPlanChangesTest(unittest.TestCase):
     def test_resource_change_is_detected(self):
         engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
@@ -211,6 +303,44 @@ class ApplyTest(unittest.TestCase):
 
             out_dir = os.path.join(d, '.terrateam-stack-plans')
             restore_stack_artifact.assert_called_once_with(state, {'stack_root': '.'})
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'stack', 'run', 'apply',
+                 '--out-dir', out_dir,
+                 '--non-interactive'])
+            self.assertEqual(result, (True, 'out', 'err'))
+
+
+class ApplyWithoutPlanTest(unittest.TestCase):
+    def test_non_stack_dir_delegates_to_base_engine(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                engine.apply_without_plan(state, {})
+
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'apply', '-auto-approve'])
+
+    def test_stack_dir_uses_stack_run_apply_without_restoring_artifact(self):
+        # There's no saved plan artifact for apply_without_plan by definition
+        # -- `stack run apply` generates the units and applies live in one
+        # step, the Stack equivalent of plain `terraform apply -auto-approve`.
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch.object(engine, '_restore_stack_artifact') as restore_stack_artifact:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                result = engine.apply_without_plan(state, {})
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            restore_stack_artifact.assert_not_called()
             self.assertEqual(
                 run.call_args[0][1]['cmd'],
                 ['terragrunt', 'stack', 'run', 'apply',
@@ -304,6 +434,33 @@ class StackShowTest(unittest.TestCase):
                 engine.diff(state, {})
 
             restore_stack_artifact.assert_called_once_with(state, {})
+
+
+class OutputsTest(unittest.TestCase):
+    def test_non_stack_dir_delegates_to_base_engine(self):
+        with tempfile.TemporaryDirectory() as d:
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), '{}', 'err')
+                engine.outputs(state, {})
+
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', 'output', '-json'])
+
+    def test_stack_dir_skips_collection(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                result = engine.outputs(state, {})
+
+            self.assertIsNone(result)
+            run.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -171,6 +171,30 @@ class StackShowTest(unittest.TestCase):
             self.assertTrue(ok)
             self.assertEqual(payload, {'vpc': {'format_version': '1.0'}})
 
+    def test_show_cmd_uses_working_dir_flag_pointing_at_generated_unit(self):
+        # --out-dir only copies the plan file, not the unit's terragrunt.hcl
+        # (that stays where `stack generate` originally wrote it, under
+        # working_dir/<unit>, not under out_dir/<unit>). Plain `terragrunt
+        # show` run with cwd=working_dir (the stack root, which only has
+        # terragrunt.stack.hcl) fails outright, so the command must pass
+        # --working-dir pointing at the real generated unit directory.
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            out_dir = os.path.join(d, '.terrateam-stack-plans')
+            self._make_unit_plan(out_dir, 'vpc')
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run:
+                run.return_value = (SimpleNamespace(returncode=0), 'no changes', 'err')
+                engine.diff(state, {})
+
+            plan_path = os.path.join(out_dir, 'vpc', 'tfplan.tfplan')
+            self.assertEqual(
+                run.call_args[0][1]['cmd'],
+                ['terragrunt', '--working-dir', os.path.join(d, 'vpc'), 'show', plan_path])
+
     def test_diff_untars_when_units_dir_missing(self):
         # Simulates a fresh job (e.g. a re-run) where the plan directory was
         # never populated by plan() in this process and must come back from

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -93,6 +93,66 @@ class PlanTest(unittest.TestCase):
             self.assertEqual(result, (False, False, 'out', 'err'))
             tar_dir.assert_not_called()
 
+    def test_stack_plan_inspects_unit_plans_when_exit_code_is_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._tar_dir') as tar_dir, \
+                 mock.patch.object(engine, '_stack_plan_has_changes', return_value=(True, True, '')) as inspect:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                result = engine.plan(state, {})
+
+            self.assertEqual(result, (True, True, 'out', 'err'))
+            inspect.assert_called_once_with(state)
+            tar_dir.assert_called_once()
+
+    def test_stack_plan_fails_safely_when_zero_exit_code_cannot_be_inspected(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            state = _state(d)
+
+            with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
+                 mock.patch('engine_terragrunt._tar_dir') as tar_dir, \
+                 mock.patch.object(engine, '_stack_plan_has_changes', return_value=(False, False, 'show failed')):
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                result = engine.plan(state, {})
+
+            self.assertEqual(result, (False, False, 'out', 'err\nshow failed'))
+            tar_dir.assert_not_called()
+
+
+class StackPlanChangesTest(unittest.TestCase):
+    def test_resource_change_is_detected(self):
+        engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+        payload = json.dumps({
+            'resource_changes': [{'change': {'actions': ['create']}}],
+        })
+
+        with mock.patch.object(engine, '_stack_show', return_value=(True, [('unit', True, payload, '')])):
+            self.assertEqual(engine._stack_plan_has_changes(_state('/tmp')), (True, True, ''))
+
+    def test_output_change_is_detected(self):
+        engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+        payload = json.dumps({
+            'output_changes': {'endpoint': {'actions': ['update']}},
+        })
+
+        with mock.patch.object(engine, '_stack_show', return_value=(True, [('unit', True, payload, '')])):
+            self.assertEqual(engine._stack_plan_has_changes(_state('/tmp')), (True, True, ''))
+
+    def test_noop_plans_are_not_changes(self):
+        engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+        payload = json.dumps({
+            'resource_changes': [{'change': {'actions': ['no-op']}}],
+        })
+
+        with mock.patch.object(engine, '_stack_show', return_value=(True, [('unit', True, payload, '')])):
+            self.assertEqual(engine._stack_plan_has_changes(_state('/tmp')), (True, False, ''))
+
 
 class ApplyTest(unittest.TestCase):
     def test_non_stack_dir_delegates_to_base_engine(self):

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -168,7 +168,7 @@ class ApplyTest(unittest.TestCase):
                 run.call_args[0][1]['cmd'],
                 ['terragrunt', 'apply', '${TERRATEAM_PLAN_FILE}'])
 
-    def test_stack_dir_untars_then_uses_stack_run_apply(self):
+    def test_stack_dir_regenerates_units_then_uses_stack_run_apply(self):
         with tempfile.TemporaryDirectory() as d:
             open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
             engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
@@ -176,13 +176,19 @@ class ApplyTest(unittest.TestCase):
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
                  mock.patch('engine_terragrunt._untar_dir') as untar_dir:
-                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
+                run.side_effect = [
+                    (SimpleNamespace(returncode=0), 'generate out', 'generate err'),
+                    (SimpleNamespace(returncode=0), 'out', 'err'),
+                ]
                 result = engine.apply(state, {})
 
             out_dir = os.path.join(d, '.terrateam-stack-plans')
             untar_dir.assert_called_once_with('/tmp/plan', out_dir)
             self.assertEqual(
-                run.call_args[0][1]['cmd'],
+                run.call_args_list[0][0][1]['cmd'],
+                ['terragrunt', 'stack', 'generate', '--non-interactive'])
+            self.assertEqual(
+                run.call_args_list[1][0][1]['cmd'],
                 ['terragrunt', 'stack', 'run', 'apply',
                  '--out-dir', out_dir,
                  '--non-interactive',

--- a/terrat_runner/test_engine_terragrunt.py
+++ b/terrat_runner/test_engine_terragrunt.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tarfile
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -62,7 +63,7 @@ class PlanTest(unittest.TestCase):
             state = _state(d)
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._tar_dir') as tar_dir:
+                 mock.patch.object(engine, '_tar_stack_artifact') as tar_stack_artifact:
                 run.return_value = (SimpleNamespace(returncode=2), 'out', 'err')
                 result = engine.plan(state, {'extra_args': ['-var=foo=bar']})
 
@@ -77,7 +78,7 @@ class PlanTest(unittest.TestCase):
                  '-var=foo=bar'])
             # exit code 2 == has changes, and must still be treated as success.
             self.assertEqual(result, (True, True, 'out', 'err'))
-            tar_dir.assert_called_once_with(out_dir, '/tmp/plan')
+            tar_stack_artifact.assert_called_once_with(state)
 
     def test_stack_plan_failure_does_not_tar(self):
         with tempfile.TemporaryDirectory() as d:
@@ -86,12 +87,12 @@ class PlanTest(unittest.TestCase):
             state = _state(d)
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._tar_dir') as tar_dir:
+                 mock.patch.object(engine, '_tar_stack_artifact') as tar_stack_artifact:
                 run.return_value = (SimpleNamespace(returncode=1), 'out', 'err')
                 result = engine.plan(state, {})
 
             self.assertEqual(result, (False, False, 'out', 'err'))
-            tar_dir.assert_not_called()
+            tar_stack_artifact.assert_not_called()
 
     def test_stack_plan_inspects_unit_plans_when_exit_code_is_zero(self):
         with tempfile.TemporaryDirectory() as d:
@@ -100,14 +101,14 @@ class PlanTest(unittest.TestCase):
             state = _state(d)
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._tar_dir') as tar_dir, \
+                 mock.patch.object(engine, '_tar_stack_artifact') as tar_stack_artifact, \
                  mock.patch.object(engine, '_stack_plan_has_changes', return_value=(True, True, '')) as inspect:
                 run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
                 result = engine.plan(state, {})
 
             self.assertEqual(result, (True, True, 'out', 'err'))
             inspect.assert_called_once_with(state)
-            tar_dir.assert_called_once()
+            tar_stack_artifact.assert_called_once_with(state)
 
     def test_stack_plan_fails_safely_when_zero_exit_code_cannot_be_inspected(self):
         with tempfile.TemporaryDirectory() as d:
@@ -116,13 +117,40 @@ class PlanTest(unittest.TestCase):
             state = _state(d)
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._tar_dir') as tar_dir, \
+                 mock.patch.object(engine, '_tar_stack_artifact') as tar_stack_artifact, \
                  mock.patch.object(engine, '_stack_plan_has_changes', return_value=(False, False, 'show failed')):
                 run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
                 result = engine.plan(state, {})
 
             self.assertEqual(result, (False, False, 'out', 'err\nshow failed'))
-            tar_dir.assert_not_called()
+            tar_stack_artifact.assert_not_called()
+
+
+class StackArtifactTest(unittest.TestCase):
+    def test_artifact_contains_manifest_root_config_and_plans_only(self):
+        with tempfile.TemporaryDirectory() as d:
+            plan_file = os.path.join(d, 'plan.tar')
+            state = _state(d)
+            state.env['TERRATEAM_PLAN_FILE'] = plan_file
+            with open(os.path.join(d, 'terragrunt.stack.hcl'), 'w') as f:
+                f.write('unit "app" {}')
+            plan_dir = os.path.join(d, '.terrateam-stack-plans', 'app')
+            os.makedirs(plan_dir)
+            open(os.path.join(plan_dir, 'tfplan.tfplan'), 'w').close()
+            runtime_dir = os.path.join(d, '.terragrunt-stack', 'app', '.terraform')
+            os.makedirs(runtime_dir)
+            open(os.path.join(runtime_dir, 'provider'), 'w').close()
+
+            engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
+            engine._tar_stack_artifact(state)
+
+            with tarfile.open(plan_file) as tar:
+                names = tar.getnames()
+            self.assertIn('.terrateam-stack-artifact.json', names)
+            self.assertIn('stack/terragrunt.stack.hcl', names)
+            self.assertIn('.terrateam-stack-plans/app/tfplan.tfplan', names)
+            self.assertFalse(any('.terraform' in name for name in names))
+            self.assertEqual(engine._load_stack_artifact_manifest(state)['engine'], 'terragrunt-stack')
 
 
 class StackPlanChangesTest(unittest.TestCase):
@@ -168,31 +196,26 @@ class ApplyTest(unittest.TestCase):
                 run.call_args[0][1]['cmd'],
                 ['terragrunt', 'apply', '${TERRATEAM_PLAN_FILE}'])
 
-    def test_stack_dir_regenerates_units_then_uses_stack_run_apply(self):
+    def test_stack_dir_restores_artifact_then_runs_stack_apply(self):
         with tempfile.TemporaryDirectory() as d:
-            open(os.path.join(d, 'terragrunt.stack.hcl'), 'w').close()
             engine = engine_terragrunt.make(override_tf_cmd='terragrunt')
             state = _state(d)
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._untar_dir') as untar_dir:
-                run.side_effect = [
-                    (SimpleNamespace(returncode=0), 'generate out', 'generate err'),
-                    (SimpleNamespace(returncode=0), 'out', 'err'),
-                ]
+                 mock.patch.object(engine, '_load_stack_artifact_manifest', return_value={
+                     'stack_root': '.',
+                 }), \
+                 mock.patch.object(engine, '_restore_stack_artifact') as restore_stack_artifact:
+                run.return_value = (SimpleNamespace(returncode=0), 'out', 'err')
                 result = engine.apply(state, {})
 
             out_dir = os.path.join(d, '.terrateam-stack-plans')
-            untar_dir.assert_called_once_with('/tmp/plan', out_dir)
+            restore_stack_artifact.assert_called_once_with(state, {'stack_root': '.'})
             self.assertEqual(
-                run.call_args_list[0][0][1]['cmd'],
-                ['terragrunt', 'stack', 'generate', '--non-interactive'])
-            self.assertEqual(
-                run.call_args_list[1][0][1]['cmd'],
+                run.call_args[0][1]['cmd'],
                 ['terragrunt', 'stack', 'run', 'apply',
                  '--out-dir', out_dir,
-                 '--non-interactive',
-                 '--'])
+                 '--non-interactive'])
             self.assertEqual(result, (True, 'out', 'err'))
 
 
@@ -271,15 +294,16 @@ class StackShowTest(unittest.TestCase):
             state = _state(d)
             out_dir = os.path.join(d, '.terrateam-stack-plans')
 
-            def fake_untar(_src, dest):
-                self._make_unit_plan(dest, 'vpc')
+            def fake_restore(_state, _manifest):
+                self._make_unit_plan(out_dir, 'vpc')
 
             with mock.patch('engine_terragrunt.cmd.run_with_output') as run, \
-                 mock.patch('engine_terragrunt._untar_dir', side_effect=fake_untar) as untar_dir:
+                 mock.patch.object(engine, '_load_stack_artifact_manifest', return_value={}), \
+                 mock.patch.object(engine, '_restore_stack_artifact', side_effect=fake_restore) as restore_stack_artifact:
                 run.return_value = (SimpleNamespace(returncode=0), 'no changes', 'err')
                 engine.diff(state, {})
 
-            untar_dir.assert_called_once_with('/tmp/plan', out_dir)
+            restore_stack_artifact.assert_called_once_with(state, {})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Terragrunt Stacks (`terragrunt.stack.hcl` / `terragrunt stack run <verb>`) currently don't work with this action: a Stack root directory has no `terragrunt.hcl` of its own, so every existing engine command (`plan`, `apply`, `output`, `init`, `show`, ...) fails immediately with "does not contain a terragrunt.hcl file", since they all run a plain `terragrunt <cmd>` against the Stack root.

This adds Stack-awareness to the Terragrunt engine (`terrat_runner/engine_terragrunt.py`):

- **Detection**: a directory is treated as a Stack if it contains `terragrunt.stack.hcl`.
- **`plan()`**: runs `terragrunt stack run plan --out-dir <dir> --non-interactive -- -detailed-exitcode`, then tars up the generated per-unit plan files plus the root Stack config into Terrateam's existing single-file plan storage (`TERRATEAM_PLAN_FILE`), alongside an explicit manifest (`.terrateam-stack-artifact.json`: format version, engine name, Stack root path, and a checksum of the root config).
- **`apply()`**: restores that artifact (validating the manifest and the checksum -- refusing to proceed if the root Stack config has changed since the plan, e.g. from a later commit landing on the PR branch), then runs `terragrunt stack run apply --out-dir <dir> --non-interactive`.
- **`diff()` / `diff_json()`**: run `terragrunt show` per generated unit (using `--working-dir` rather than `cwd`, since `--out-dir` only copies the plan file, not the unit's own generated config).
- **`outputs()` / `init()` / `apply_without_plan()`**: made no-ops (skip cleanly) for Stacks, since a Stack has no single root-level output set, and `stack run plan`/`apply` already initialize each generated unit themselves.

## Test plan

Validated against real GCP infrastructure end to end, not just unit tests:

- Single-unit Stack: full create -> destroy lifecycle via real `plan`/`apply`, twice (once to create, once to destroy via an `enabled` toggle in the module).
- Two-unit Stack with a real cross-unit dependency (a native Terragrunt `dependency` block reading one unit's output into another): `plan`/`apply` both correctly resolve the real (non-mock) output and produce a correctly dependency-ordered plan, once the depended-upon unit has been applied at least once.
- 27 unit tests covering the manifest protocol, artifact restore (including its rejection paths: checksum mismatch, root config changed after plan, and a symlink member attempting to escape the workspace), and the outputs/init/apply_without_plan stack-awareness fixes.

## Known limitation

A brand-new multi-unit Stack where a unit depends on another via a `dependency` block, and neither unit has ever been applied (so Terragrunt must fall back to `mock_outputs` to complete the very first plan), has been observed to fail in one CI environment we tested against, with Terragrunt reporting `Unknown variable: dependency` during its internal dependency pre-resolution -- while the identical fixture, using the identical command this engine issues, succeeds locally (macOS, two separate Terragrunt versions). We ruled out Terragrunt version, binary/download integrity, and GCS IAM permission scoping as causes without finding a root cause. Since this engine only shells out to `terragrunt stack run plan/apply` -- dependency resolution and `mock_outputs` handling are entirely Terragrunt's own logic -- this isn't something we can fix here. The workaround (also the normal pattern for a from-scratch dependency chain) is to apply the depended-upon unit at least once before the first plan/apply of units that depend on it.

## Security

`_restore_stack_artifact`'s tar extraction previously only checked each member's own name for path traversal, not what a symlink/hardlink member's target pointed at. Since the restored directory is immediately reused as Terragrunt's `--out-dir` for a real apply, a maliciously-crafted plan artifact (reachable by anyone who can influence the Terragrunt/Terraform config being planned, e.g. via a `generate` block or hook) could place a symlink that redirects Terragrunt's real writes outside the checkout. Fixed by passing `filter='data'` to `extractall` (stdlib, Python 3.12+), with a regression test.