### PR TITLE
stategraph/mono#1992 FIX base image: consume refreshed base and retry tenv installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1776595483
+ARG BASE_IMAGE=ghcr.io/terrateamio/action-base:1788854514
 FROM ${BASE_IMAGE}
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -39,12 +39,13 @@ ARG TERRAFORM_VERSIONS=
 # Install tofu and terraform versions dynamically based on TOFU_VERSIONS and TERRAFORM_VERSIONS. versions should be comma separated.
 RUN set -e; \
     retry() { \
-        n=0; \
-        until [ "${n}" -ge 3 ]; do \
-            "$@" && return 0; \
-            n=$((n + 1)); \
-            echo "retry ${n}/3: $*" >&2; \
+        n=1; \
+        while true; do \
+            if "$@"; then return 0; fi; \
+            if [ "${n}" -ge 3 ]; then break; fi; \
+            echo "attempt ${n}/3 failed, retrying in $((n * 10))s: $*" >&2; \
             sleep $((n * 10)); \
+            n=$((n + 1)); \
         done; \
         echo "failed after 3 attempts: $*" >&2; \
         return 1; \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -38,8 +38,19 @@ ARG TOFU_VERSIONS=1.12.6
 ARG TERRAFORM_VERSIONS=
 # Install tofu and terraform versions dynamically based on TOFU_VERSIONS and TERRAFORM_VERSIONS. versions should be comma separated.
 RUN set -e; \
-    for version in $(echo "${TOFU_VERSIONS}" | tr ',' ' '); do tenv tofu install "${version}"; sleep 5; done; \
-    for version in $(echo "${TERRAFORM_VERSIONS}" | tr ',' ' '); do tenv terraform install "${version}"; sleep 5; done
+    retry() { \
+        n=0; \
+        until [ "${n}" -ge 3 ]; do \
+            "$@" && return 0; \
+            n=$((n + 1)); \
+            echo "retry ${n}/3: $*" >&2; \
+            sleep $((n * 10)); \
+        done; \
+        echo "failed after 3 attempts: $*" >&2; \
+        return 1; \
+    }; \
+    for version in $(echo "${TOFU_VERSIONS}" | tr ',' ' '); do retry tenv tofu install "${version}"; sleep 5; done; \
+    for version in $(echo "${TERRAFORM_VERSIONS}" | tr ',' ' '); do retry tenv terraform install "${version}"; sleep 5; done
 
 ENV INFRACOST_VERSION=v0.10.45
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g') && \


### PR DESCRIPTION
Follow-up to #681.

- Repoints `BASE_IMAGE` at `ghcr.io/terrateamio/action-base:1788854514`, the first base built from #681's `Dockerfile.base`.
- Adds a 3-attempt retry with backoff to the `tenv` install loop. The first `base.yaml` run failed on `connection reset by peer` fetching an OpenTofu release asset; there was no retry, so one reset killed the whole multi-arch build.

Fixable HIGH/CRITICAL in the base image: 336 → 48, CRITICAL 16 → 3. OS packages go to zero; the remainder is upstream CVEs in the conftest, infracost and OpenTofu binaries.

The retry applies to the next base build, not the image pinned here.
