### PR TITLE
stategraph/mono#1992 FIX indexer: default to the image that is still built

### DIFF
--- a/terrat_runner/runtime/github_actions/runtime.py
+++ b/terrat_runner/runtime/github_actions/runtime.py
@@ -46,7 +46,7 @@ class Runtime(object):
 
     def work_index(self, state):
         indexer_conf = rc.get_indexer(state.repo_config)
-        build_tag = indexer_conf.get('build_tag', 'ghcr.io/terrateamio/terrat-code-indexer:latest')
+        build_tag = indexer_conf.get('build_tag', 'ghcr.io/terrateamio/code-indexer:latest')
         cmd.run(state, {'cmd': ['apt-get', 'update']})
         cmd.run(state, {'cmd': ['apt-get', 'install', '-y', 'docker.io', 'musl']})
         cmd.run(state, {'cmd': ['docker', 'pull', build_tag]})

--- a/terrat_runner/runtime/gitlab_ci/runtime.py
+++ b/terrat_runner/runtime/gitlab_ci/runtime.py
@@ -22,7 +22,7 @@ class Runtime(object):
 
     def work_index(self, state):
         indexer_conf = rc.get_indexer(state.repo_config)
-        build_tag = indexer_conf.get('build_tag', 'ghcr.io/terrateamio/terrat-code-indexer:latest')
+        build_tag = indexer_conf.get('build_tag', 'ghcr.io/terrateamio/code-indexer:latest')
         cmd.run(state, {'cmd': ['apt-get', 'update']})
         cmd.run(state, {'cmd': ['apt-get', 'install', '-y', 'docker.io', 'musl']})
         cmd.run(state, {'cmd': ['docker', 'pull', build_tag]})


### PR DESCRIPTION
Both runtimes default the indexer image to `ghcr.io/terrateamio/terrat-code-indexer:latest`. **That tag was last published on 2024-11-08.** Nothing builds it any more — no workflow in `stategraph/mono` or in this repository pushes to it. Every customer with the indexer enabled and no explicit `build_tag` pulls a nearly two-year-old image, on Alpine 3.18.9, which Alpine no longer supports.

`ghcr.io/terrateamio/code-indexer:latest` is the same tool, still built, and was last published on 2026-09-07 on Alpine 3.23.5. The weekly container scan reports it at zero vulnerabilities of any severity, against 2 fixable HIGH for the stale tag.

The runner does not run the image. It pulls it, `docker cp`s `/usr/local/bin/terrat_code_indexer` out, throws the container away, and runs the binary against the action image's musl loader. So the only thing that has to match is that binary.

## Verification

Both images carry `/usr/local/bin/terrat_code_indexer`, and both expose the same CLI:

```
COMMANDS
       index [OPTION]… PATH…
           Index paths
```

`index` takes only paths and `--help` in both. Ran both binaries over the same fixture — a directory with a `module` block pointing at a sibling — and the output is identical, byte for byte:

```json
{
  "version": 1,
  "paths": { "dir1": { "modules": [ "../mod" ], "failures": {} } },
  "symlinks": {}
}
```

Same `version: 1` the runner's fallback assumes, same `paths` shape, same `symlinks` key. The binaries differ in size (8,157,096 vs 6,368,672 bytes) because they are two years apart, not because they do different things.

`python3 -m py_compile` passes on both changed files.

## Note

`build_tag` still overrides this, so anyone pinning `terrat-code-indexer` explicitly is unaffected. The docs change that follows this is in `stategraph/mono`, in `docs/src/content/docs/reference/configuration/indexer.mdx`.
