### PR TITLE
stategraph/mono#2094 REFACTOR Ask the compute node for work

### DIFF
--- a/terrat_runner/main.py
+++ b/terrat_runner/main.py
@@ -256,6 +256,12 @@ def run(args, env):
 
     result_version = wm.get('result_version', 1)
 
+    # [args.work_token] names the compute node, and the compute node can perform
+    # more than one work manifest.  Every other call is against a work manifest,
+    # so those calls use the id that this response gives.  A server that does not
+    # send an id gives a compute node id that is also the work manifest id.
+    work_token = wm.get('id') or args.work_token
+
     state = run_state.create(
         api_base_url=args.api_base_url,
         api_token=wm['token'],
@@ -264,7 +270,7 @@ def run(args, env):
         env=env,
         sha=args.sha,
         work_manifest=wm,
-        work_token=args.work_token,
+        work_token=work_token,
         working_dir=args.workspace,
         result_version=result_version
     )

--- a/terrat_runner/test_api.py
+++ b/terrat_runner/test_api.py
@@ -1,7 +1,10 @@
 import unittest
+import unittest.mock
 
 import api
+import requests_retry
 import run_state
+import work_manifest
 
 
 def state():
@@ -27,6 +30,58 @@ class UrlTest(unittest.TestCase):
                          api._url(state(), 'plans'))
         self.assertEqual('https://app.terrateam.io/v1/work-manifests/wm-123/access-token',
                          api._url(state(), 'access-token'))
+
+
+class WorkManifestUrlTest(unittest.TestCase):
+    def test_initiate_asks_the_compute_node(self):
+        self.assertEqual('https://app.terrateam.io/v1/compute-node/cn-123/initiate',
+                         work_manifest._url('https://app.terrateam.io', 'cn-123'))
+
+    def test_the_fallback_asks_the_work_manifest(self):
+        self.assertEqual('https://app.terrateam.io/v1/work-manifests/cn-123/initiate',
+                         work_manifest._legacy_url('https://app.terrateam.io', 'cn-123'))
+
+
+def _response(status_code, body=None):
+    r = unittest.mock.Mock()
+    r.status_code = status_code
+    r.text = ''
+    r.json.return_value = body if body is not None else {}
+    return r
+
+
+class WorkManifestGetTest(unittest.TestCase):
+    # A server that has the compute node endpoint is asked one time only.
+    def test_a_new_server_is_asked_once(self):
+        wm = {'type': 'build-tree', 'id': 'wm-1'}
+        with unittest.mock.patch.object(requests_retry, 'post',
+                                        return_value=_response(200, wm)) as post:
+            self.assertEqual(wm, work_manifest.get('https://x', 'cn-1', 'run-1', 'sha-1'))
+        self.assertEqual(1, post.call_count)
+        self.assertEqual('https://x/v1/compute-node/cn-1/initiate',
+                         post.call_args.kwargs['url'])
+
+    # A server that predates the endpoint gives 404, so the work manifest URL is
+    # asked, and the run continues.
+    def test_an_old_server_falls_back(self):
+        wm = {'type': 'build-tree'}
+        with unittest.mock.patch.object(
+                requests_retry, 'post',
+                side_effect=[_response(404), _response(200, wm)]) as post:
+            self.assertEqual(wm, work_manifest.get('https://x', 'wm-1', 'run-1', 'sha-1'))
+        self.assertEqual(2, post.call_count)
+        self.assertEqual('https://x/v1/compute-node/wm-1/initiate',
+                         post.call_args_list[0].kwargs['url'])
+        self.assertEqual('https://x/v1/work-manifests/wm-1/initiate',
+                         post.call_args_list[1].kwargs['url'])
+
+    # An unknown work token gives 404 from both URLs, which still stops the run.
+    def test_an_unknown_token_still_raises(self):
+        with unittest.mock.patch.object(
+                requests_retry, 'post',
+                side_effect=[_response(404), _response(404)]):
+            with self.assertRaises(work_manifest.NoWorkManifestError):
+                work_manifest.get('https://x', 'nope', 'run-1', 'sha-1')
 
 
 class HeadersTest(unittest.TestCase):

--- a/terrat_runner/work_manifest.py
+++ b/terrat_runner/work_manifest.py
@@ -7,12 +7,30 @@ class NoWorkManifestError(Exception):
     pass
 
 
+# The work token names a compute node.  A compute node can perform more than one
+# work manifest, so the response names the work manifest that this iteration must
+# operate on.  See [main.run].
+def _url(api_base_url, work_token):
+    return api_base_url + '/v1/compute-node/' + work_token + '/initiate'
+
+
+# A server that predates the compute node endpoint.  Such a server gives a work
+# token that is a work manifest id, and it answers this URL.
+def _legacy_url(api_base_url, work_token):
+    return api_base_url + '/v1/work-manifests/' + work_token + '/initiate'
+
+
 def get(api_base_url, work_token, run_id, sha):
-    r = requests_retry.post(url=api_base_url + '/v1/work-manifests/' + work_token + '/initiate',
-                            json={
-                                'run_id': run_id,
-                                'sha': sha
-                            })
+    body = {'run_id': run_id, 'sha': sha}
+    r = requests_retry.post(url=_url(api_base_url, work_token), json=body)
+
+    if r.status_code == 404:
+        # The compute node endpoint and an unknown work token both give 404, so
+        # ask the older URL before the run stops.  A server that has the compute
+        # node endpoint answers it, thus this second call happens one time only,
+        # against a server that predates the endpoint.
+        logging.info('COMPUTE_NODE_INITIATE_NOT_FOUND : trying the work manifest URL')
+        r = requests_retry.post(url=_legacy_url(api_base_url, work_token), json=body)
 
     if r.status_code == 404:
         logging.error('%s', r.text)


### PR DESCRIPTION
The work token names a compute node, and RFD 2094 lets a compute node perform more than one work manifest.  So initiate goes to compute-node/<token>/initiate, and the response names the work manifest of this iteration.  Every other call is against a work manifest, so those calls use that id.

A server that predates this endpoint answers it with 404, so the older URL is asked before the run stops.  Without that fallback a new action against an older server stops with a message about a manual run, which is not the cause.  A server that has the endpoint answers the first call, so the second call happens against an older server only.

A server that does not send an id gives a compute node id that is also the work manifest id, so the fallback for the id keeps such a server working too.

The loop does not change.  It already asks again until it gets a done response.